### PR TITLE
Fix book deployment job

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -37,5 +37,5 @@ jobs:
     - uses: alex-page/blazing-fast-gh-pages-deploy@v1.1.0
       with:
         repo-token: ${{ secrets.GH_PAT }}
-        site-directory: ./book/book
+        site-directory: ./book
         commit-message: Deploy to GitHub Pages


### PR DESCRIPTION
The path was wrong. This should fix it. The current deployment was not broken by the failed job.