### PR TITLE
Add parser module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,9 @@ description = "An open specification for complex data structures over hardware s
 authors = ["Johan Peltenburg", "Jeroen van Straten", "Matthijs Brobbel"]
 edition = "2018"
 
+[features]
+default = ["parser"]
+parser = ["nom"]
+
 [dependencies]
+nom = { version = "5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,56 @@
+#[cfg(feature = "parser")]
+pub mod parser;
 
+/// High level data types.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Data {
+    /// Empty
+    Empty,
+    /// Prim<B>
+    Prim(usize),
+    /// Struct<T, U, ...>
+    Struct(Vec<Data>),
+    /// Tuple<T, n>
+    Tuple(Box<Data>, usize),
+    /// Seq<T>
+    Seq(Box<Data>),
+    /// Variant<T, U, ...>
+    Variant(Vec<Data>),
+}
+
+/// River types.
+#[derive(Clone, Debug, PartialEq)]
+pub enum River {
+    /// Bits<b>
+    Bits(usize),
+    /// Root<T, N, C, U>
+    Root(Box<River>, RiverParameters),
+    /// Group<T, U, ...>
+    Group(Vec<River>),
+    /// Dim<T, N, C, U>
+    Dim(Box<River>, RiverParameters),
+    /// New<T, N, C, U>
+    New(Box<River>, RiverParameters),
+    /// Rev<T, N, C, U>
+    Rev(Box<River>, RiverParameters),
+    /// Union<T, U, ...>
+    Union(Vec<River>),
+}
+
+/// Parameters of River types.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct RiverParameters {
+    /// N: number of elements per handshake.
+    pub elements: Option<usize>,
+    /// C: complexity level.
+    pub complexity: Option<usize>,
+    /// U: number of user bits.
+    pub userbits: Option<usize>,
+}
+
+/// Streamlet interface definition.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Streamlet {
+    pub input: Vec<River>,
+    pub output: Vec<River>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,12 @@ pub enum Data {
     /// Struct<T, U, ...>
     Struct {
         identifier: Option<String>,
-        childs: Vec<Data>,
+        children: Vec<Data>,
     },
     /// Variant<T, U, ...>
     Variant {
         identifier: Option<String>,
-        childs: Vec<Data>,
+        children: Vec<Data>,
     },
 }
 
@@ -69,12 +69,12 @@ pub enum River {
     /// Group<T, U, ...>
     Group {
         identifier: Option<String>,
-        childs: Vec<River>,
+        children: Vec<River>,
     },
     /// Union<T, U, ...>
     Union {
         identifier: Option<String>,
-        childs: Vec<River>,
+        children: Vec<River>,
     },
 }
 
@@ -98,10 +98,12 @@ impl River {
             } => {
                 parameters.elements.unwrap_or(1) * child.width() + parameters.userbits.unwrap_or(0)
             }
-            River::Group { childs, .. } => childs.iter().map(|child| child.width()).sum(),
-            River::Union { childs, .. } => {
-                childs.iter().map(|child| child.width()).max().unwrap_or(0)
-            }
+            River::Group { children, .. } => children.iter().map(|child| child.width()).sum(),
+            River::Union { children, .. } => children
+                .iter()
+                .map(|child| child.width())
+                .max()
+                .unwrap_or(0),
         }
     }
 }
@@ -185,7 +187,7 @@ mod tests {
         assert_eq!(
             River::Group {
                 identifier: None,
-                childs: vec![
+                children: vec![
                     River::Bits {
                         identifier: None,
                         width: 3
@@ -202,7 +204,7 @@ mod tests {
         assert_eq!(
             River::Union {
                 identifier: None,
-                childs: vec![
+                children: vec![
                     River::Bits {
                         identifier: None,
                         width: 3

--- a/src/parser/data.rs
+++ b/src/parser/data.rs
@@ -1,0 +1,151 @@
+use crate::{
+    parser::{nonempty_comma_list, r#type, space_opt, usize},
+    Data,
+};
+use nom::{
+    branch::alt, bytes::complete::tag, character::complete::char, combinator::map,
+    sequence::separated_pair, IResult,
+};
+
+/// Parses an Empty.
+pub fn empty(input: &str) -> IResult<&str, Data> {
+    map(tag("Empty"), |_| Data::Empty)(input)
+}
+
+/// Parses a Prim<B>.
+pub fn prim(input: &str) -> IResult<&str, Data> {
+    map(r#type("Prim", usize), Data::Prim)(input)
+}
+
+/// Parses a Struct<T, U, ...>.
+pub fn r#struct(input: &str) -> IResult<&str, Data> {
+    map(
+        r#type("Struct", nonempty_comma_list(data_type)),
+        Data::Struct,
+    )(input)
+}
+
+/// Parses a Tuple<T, n>.
+pub fn tuple(input: &str) -> IResult<&str, Data> {
+    map(
+        r#type(
+            "Tuple",
+            separated_pair(data_type, space_opt(char(',')), usize),
+        ),
+        |(data_type, count)| Data::Tuple(Box::new(data_type), count),
+    )(input)
+}
+
+/// Parses a Seq<T>.
+pub fn seq(input: &str) -> IResult<&str, Data> {
+    map(r#type("Seq", data_type), |data_type| {
+        Data::Seq(Box::new(data_type))
+    })(input)
+}
+
+/// Parses a Variant<T, U, ...>.
+pub fn variant(input: &str) -> IResult<&str, Data> {
+    map(
+        r#type("Variant", nonempty_comma_list(data_type)),
+        Data::Variant,
+    )(input)
+}
+
+/// Parses a Data type.
+pub fn data_type(input: &str) -> IResult<&str, Data> {
+    alt((variant, seq, tuple, r#struct, prim, empty))(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_empty() {
+        assert_eq!(empty("Empty"), Ok(("", Data::Empty)));
+    }
+
+    #[test]
+    fn parse_prim() {
+        assert_eq!(prim("Prim<8>"), Ok(("", Data::Prim(8))));
+        assert!(prim("Prim<>").is_err());
+        assert!(prim("prim<8>").is_err());
+    }
+
+    #[test]
+    fn parse_struct() {
+        assert_eq!(
+            r#struct("Struct<Prim<3>>"),
+            Ok(("", Data::Struct(vec![Data::Prim(3)])))
+        );
+        assert_eq!(
+            r#struct("Struct<Struct<Prim<3>>>"),
+            Ok(("", Data::Struct(vec![Data::Struct(vec![Data::Prim(3)])])))
+        );
+        assert_eq!(
+            r#struct("Struct<Struct<Prim<3>,Prim<8>>>"),
+            Ok((
+                "",
+                Data::Struct(vec![Data::Struct(vec![Data::Prim(3), Data::Prim(8)])])
+            ))
+        );
+        assert_eq!(
+            r#struct("Struct<Struct<Prim<3>,Prim<8>>>"),
+            r#struct("Struct<Struct<Prim<3>, Prim<8>>>"),
+        );
+    }
+
+    #[test]
+    fn parse_tuple() {
+        assert_eq!(
+            tuple("Tuple<Prim<8>,4>"),
+            Ok(("", Data::Tuple(Box::new(Data::Prim(8)), 4)))
+        );
+    }
+
+    #[test]
+    fn parse_seq() {
+        assert_eq!(
+            seq("Seq<Tuple<Prim<8>,4>>"),
+            Ok((
+                "",
+                Data::Seq(Box::new(Data::Tuple(Box::new(Data::Prim(8)), 4)))
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_variant() {
+        assert_eq!(
+            variant("Variant<Prim<8>, Seq<Tuple<Prim<8>,4>>>"),
+            Ok((
+                "",
+                Data::Variant(vec![
+                    Data::Prim(8),
+                    Data::Seq(Box::new(Data::Tuple(Box::new(Data::Prim(8)), 4)))
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_data_type() {
+        assert_eq!(data_type("Prim<8>"), Ok(("", Data::Prim(8))));
+        assert_eq!(
+            data_type("Struct<Prim<4>, Prim<4>>"),
+            Ok(("", Data::Struct(vec![Data::Prim(4), Data::Prim(4)])))
+        );
+        assert_eq!(
+            data_type("Tuple<Prim<8>, 4>"),
+            Ok(("", Data::Tuple(Box::new(Data::Prim(8)), 4)))
+        );
+        assert_eq!(
+            data_type("Seq<Prim<4>>"),
+            Ok(("", Data::Seq(Box::new(Data::Prim(4)))))
+        );
+        assert_eq!(
+            data_type("Variant<Prim<4>,Prim<4>>"),
+            Ok(("", Data::Variant(vec![Data::Prim(4), Data::Prim(4)])))
+        );
+    }
+}

--- a/src/parser/data.rs
+++ b/src/parser/data.rs
@@ -24,7 +24,10 @@ pub fn prim(input: &str) -> IResult<&str, Data> {
 pub fn r#struct(input: &str) -> IResult<&str, Data> {
     map(
         r#type("Struct", nonempty_comma_list(data_type)),
-        |(identifier, childs)| Data::Struct { identifier, childs },
+        |(identifier, children)| Data::Struct {
+            identifier,
+            children,
+        },
     )(input)
 }
 
@@ -57,7 +60,10 @@ pub fn seq(input: &str) -> IResult<&str, Data> {
 pub fn variant(input: &str) -> IResult<&str, Data> {
     map(
         r#type("Variant", nonempty_comma_list(data_type)),
-        |(identifier, childs)| Data::Variant { identifier, childs },
+        |(identifier, children)| Data::Variant {
+            identifier,
+            children,
+        },
     )(input)
 }
 
@@ -109,7 +115,7 @@ mod tests {
                 "",
                 Data::Struct {
                     identifier: None,
-                    childs: vec![Data::Prim {
+                    children: vec![Data::Prim {
                         identifier: None,
                         width: 3
                     }]
@@ -122,9 +128,9 @@ mod tests {
                 "",
                 Data::Struct {
                     identifier: None,
-                    childs: vec![Data::Struct {
+                    children: vec![Data::Struct {
                         identifier: None,
-                        childs: vec![Data::Prim {
+                        children: vec![Data::Prim {
                             identifier: None,
                             width: 3
                         }]
@@ -138,9 +144,9 @@ mod tests {
                 "",
                 Data::Struct {
                     identifier: None,
-                    childs: vec![Data::Struct {
+                    children: vec![Data::Struct {
                         identifier: None,
-                        childs: vec![
+                        children: vec![
                             Data::Prim {
                                 identifier: None,
                                 width: 3
@@ -164,7 +170,7 @@ mod tests {
                 "",
                 Data::Struct {
                     identifier: Some("a".to_string()),
-                    childs: vec![Data::Prim {
+                    children: vec![Data::Prim {
                         identifier: Some("b".to_string()),
                         width: 3
                     }]
@@ -238,7 +244,7 @@ mod tests {
                 "",
                 Data::Variant {
                     identifier: None,
-                    childs: vec![
+                    children: vec![
                         Data::Prim {
                             identifier: None,
                             width: 8
@@ -278,7 +284,7 @@ mod tests {
                 "",
                 Data::Struct {
                     identifier: None,
-                    childs: vec![
+                    children: vec![
                         Data::Prim {
                             identifier: None,
                             width: 4
@@ -324,7 +330,7 @@ mod tests {
                 "",
                 Data::Variant {
                     identifier: None,
-                    childs: vec![
+                    children: vec![
                         Data::Prim {
                             identifier: None,
                             width: 4

--- a/src/parser/data.rs
+++ b/src/parser/data.rs
@@ -14,14 +14,17 @@ pub fn empty(input: &str) -> IResult<&str, Data> {
 
 /// Parses a Prim<B>.
 pub fn prim(input: &str) -> IResult<&str, Data> {
-    map(r#type("Prim", usize), Data::Prim)(input)
+    map(r#type("Prim", usize), |(identifier, width)| Data::Prim {
+        identifier,
+        width,
+    })(input)
 }
 
 /// Parses a Struct<T, U, ...>.
 pub fn r#struct(input: &str) -> IResult<&str, Data> {
     map(
         r#type("Struct", nonempty_comma_list(data_type)),
-        Data::Struct,
+        |(identifier, childs)| Data::Struct { identifier, childs },
     )(input)
 }
 
@@ -32,14 +35,21 @@ pub fn tuple(input: &str) -> IResult<&str, Data> {
             "Tuple",
             separated_pair(data_type, space_opt(char(',')), usize),
         ),
-        |(data_type, count)| Data::Tuple(Box::new(data_type), count),
+        |(identifier, (data_type, width))| Data::Tuple {
+            identifier,
+            child: Box::new(data_type),
+            width,
+        },
     )(input)
 }
 
 /// Parses a Seq<T>.
 pub fn seq(input: &str) -> IResult<&str, Data> {
-    map(r#type("Seq", data_type), |data_type| {
-        Data::Seq(Box::new(data_type))
+    map(r#type("Seq", data_type), |(identifier, data_type)| {
+        Data::Seq {
+            identifier,
+            child: Box::new(data_type),
+        }
     })(input)
 }
 
@@ -47,7 +57,7 @@ pub fn seq(input: &str) -> IResult<&str, Data> {
 pub fn variant(input: &str) -> IResult<&str, Data> {
     map(
         r#type("Variant", nonempty_comma_list(data_type)),
-        Data::Variant,
+        |(identifier, childs)| Data::Variant { identifier, childs },
     )(input)
 }
 
@@ -67,31 +77,103 @@ mod tests {
 
     #[test]
     fn parse_prim() {
-        assert_eq!(prim("Prim<8>"), Ok(("", Data::Prim(8))));
+        assert_eq!(
+            prim("Prim<8>"),
+            Ok((
+                "",
+                Data::Prim {
+                    identifier: None,
+                    width: 8
+                }
+            ))
+        );
         assert!(prim("Prim<>").is_err());
         assert!(prim("prim<8>").is_err());
+        assert_eq!(
+            prim("a: Prim<3>"),
+            Ok((
+                "",
+                Data::Prim {
+                    identifier: Some("a".to_string()),
+                    width: 3
+                }
+            ))
+        );
     }
 
     #[test]
     fn parse_struct() {
         assert_eq!(
             r#struct("Struct<Prim<3>>"),
-            Ok(("", Data::Struct(vec![Data::Prim(3)])))
+            Ok((
+                "",
+                Data::Struct {
+                    identifier: None,
+                    childs: vec![Data::Prim {
+                        identifier: None,
+                        width: 3
+                    }]
+                }
+            ))
         );
         assert_eq!(
             r#struct("Struct<Struct<Prim<3>>>"),
-            Ok(("", Data::Struct(vec![Data::Struct(vec![Data::Prim(3)])])))
+            Ok((
+                "",
+                Data::Struct {
+                    identifier: None,
+                    childs: vec![Data::Struct {
+                        identifier: None,
+                        childs: vec![Data::Prim {
+                            identifier: None,
+                            width: 3
+                        }]
+                    }]
+                }
+            ))
         );
         assert_eq!(
             r#struct("Struct<Struct<Prim<3>,Prim<8>>>"),
             Ok((
                 "",
-                Data::Struct(vec![Data::Struct(vec![Data::Prim(3), Data::Prim(8)])])
+                Data::Struct {
+                    identifier: None,
+                    childs: vec![Data::Struct {
+                        identifier: None,
+                        childs: vec![
+                            Data::Prim {
+                                identifier: None,
+                                width: 3
+                            },
+                            Data::Prim {
+                                identifier: None,
+                                width: 8
+                            }
+                        ]
+                    }]
+                }
             ))
         );
         assert_eq!(
             r#struct("Struct<Struct<Prim<3>,Prim<8>>>"),
             r#struct("Struct<Struct<Prim<3>, Prim<8>>>"),
+        );
+        assert_eq!(
+            r#struct("a: Struct<b:Prim<3>>"),
+            Ok((
+                "",
+                Data::Struct {
+                    identifier: Some("a".to_string()),
+                    childs: vec![Data::Prim {
+                        identifier: Some("b".to_string()),
+                        width: 3
+                    }]
+                }
+            ))
+        );
+        assert_eq!(
+            r#struct("a: Struct<b:Prim<3>>"),
+            r#struct("a:Struct<b:   Prim<3>>")
         );
     }
 
@@ -99,17 +181,51 @@ mod tests {
     fn parse_tuple() {
         assert_eq!(
             tuple("Tuple<Prim<8>,4>"),
-            Ok(("", Data::Tuple(Box::new(Data::Prim(8)), 4)))
+            Ok((
+                "",
+                Data::Tuple {
+                    identifier: None,
+                    child: Box::new(Data::Prim {
+                        identifier: None,
+                        width: 8
+                    }),
+                    width: 4
+                }
+            ))
+        );
+        assert_eq!(
+            tuple("c: Tuple<c: Prim<8>,4>"),
+            Ok((
+                "",
+                Data::Tuple {
+                    identifier: Some("c".to_string()),
+                    child: Box::new(Data::Prim {
+                        identifier: Some("c".to_string()),
+                        width: 8
+                    }),
+                    width: 4
+                }
+            ))
         );
     }
 
     #[test]
     fn parse_seq() {
         assert_eq!(
-            seq("Seq<Tuple<Prim<8>,4>>"),
+            seq("Seq<Tuple<a: Prim<8>,4>>"),
             Ok((
                 "",
-                Data::Seq(Box::new(Data::Tuple(Box::new(Data::Prim(8)), 4)))
+                Data::Seq {
+                    identifier: None,
+                    child: Box::new(Data::Tuple {
+                        identifier: None,
+                        child: Box::new(Data::Prim {
+                            identifier: Some("a".to_string()),
+                            width: 8
+                        }),
+                        width: 4
+                    })
+                }
             ))
         );
     }
@@ -117,35 +233,109 @@ mod tests {
     #[test]
     fn parse_variant() {
         assert_eq!(
-            variant("Variant<Prim<8>, Seq<Tuple<Prim<8>,4>>>"),
+            variant("Variant<Prim<8>, Seq<Tuple<byte: Prim<8>,4>>>"),
             Ok((
                 "",
-                Data::Variant(vec![
-                    Data::Prim(8),
-                    Data::Seq(Box::new(Data::Tuple(Box::new(Data::Prim(8)), 4)))
-                ])
+                Data::Variant {
+                    identifier: None,
+                    childs: vec![
+                        Data::Prim {
+                            identifier: None,
+                            width: 8
+                        },
+                        Data::Seq {
+                            identifier: None,
+                            child: Box::new(Data::Tuple {
+                                identifier: None,
+                                child: Box::new(Data::Prim {
+                                    identifier: Some("byte".to_string()),
+                                    width: 8
+                                }),
+                                width: 4
+                            })
+                        }
+                    ]
+                }
             ))
         );
     }
 
     #[test]
     fn parse_data_type() {
-        assert_eq!(data_type("Prim<8>"), Ok(("", Data::Prim(8))));
+        assert_eq!(
+            data_type("Prim<8>"),
+            Ok((
+                "",
+                Data::Prim {
+                    identifier: None,
+                    width: 8
+                }
+            ))
+        );
         assert_eq!(
             data_type("Struct<Prim<4>, Prim<4>>"),
-            Ok(("", Data::Struct(vec![Data::Prim(4), Data::Prim(4)])))
+            Ok((
+                "",
+                Data::Struct {
+                    identifier: None,
+                    childs: vec![
+                        Data::Prim {
+                            identifier: None,
+                            width: 4
+                        },
+                        Data::Prim {
+                            identifier: None,
+                            width: 4
+                        }
+                    ]
+                }
+            ))
         );
         assert_eq!(
             data_type("Tuple<Prim<8>, 4>"),
-            Ok(("", Data::Tuple(Box::new(Data::Prim(8)), 4)))
+            Ok((
+                "",
+                Data::Tuple {
+                    identifier: None,
+                    child: Box::new(Data::Prim {
+                        identifier: None,
+                        width: 8
+                    }),
+                    width: 4
+                }
+            ))
         );
         assert_eq!(
             data_type("Seq<Prim<4>>"),
-            Ok(("", Data::Seq(Box::new(Data::Prim(4)))))
+            Ok((
+                "",
+                Data::Seq {
+                    identifier: None,
+                    child: Box::new(Data::Prim {
+                        identifier: None,
+                        width: 4
+                    })
+                }
+            ))
         );
         assert_eq!(
             data_type("Variant<Prim<4>,Prim<4>>"),
-            Ok(("", Data::Variant(vec![Data::Prim(4), Data::Prim(4)])))
+            Ok((
+                "",
+                Data::Variant {
+                    identifier: None,
+                    childs: vec![
+                        Data::Prim {
+                            identifier: None,
+                            width: 4
+                        },
+                        Data::Prim {
+                            identifier: None,
+                            width: 4
+                        }
+                    ]
+                }
+            ))
         );
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,55 @@
+//! Parser methods and implementations for Tydi types and formats.
+//!
+//! The parser module is enabled by the `parser` feature flag. It adds some
+//! utitity parser methods and implementations of parsers for Tydi and
+//! streamlet types.
+//!
+//! The current parsers are built using [`nom`], a parser combinators crate.
+//!
+//! [`nom`]: https://crates.io/crates/nom
+use nom::{
+    bytes::complete::tag,
+    character::complete::{char, digit1, space0},
+    combinator::map_res,
+    multi::separated_nonempty_list,
+    sequence::{delimited, preceded, terminated},
+    IResult,
+};
+
+pub mod data;
+pub mod river;
+pub mod streamlet;
+
+/// Returns a parser function to parse a Type<_> using the provided `inner`
+/// parser.
+pub(crate) fn r#type<'a, T, F>(name: &'a str, inner: F) -> impl Fn(&'a str) -> IResult<&'a str, T>
+where
+    F: Fn(&'a str) -> IResult<&'a str, T>,
+{
+    preceded(tag(name), delimited(char('<'), inner, char('>')))
+}
+
+/// Returns a parser function which allow space characters after the provided
+/// `inner` parser.
+pub(crate) fn space_opt<'a, T, F>(inner: F) -> impl Fn(&'a str) -> IResult<&'a str, T>
+where
+    F: Fn(&'a str) -> IResult<&'a str, T>,
+{
+    terminated(inner, space0)
+}
+
+/// Returns a parser function to parse non-empty comma-separated,
+/// space-optional lists.
+pub(crate) fn nonempty_comma_list<'a, T, F>(
+    inner: F,
+) -> impl Fn(&'a str) -> IResult<&'a str, Vec<T>>
+where
+    F: Fn(&'a str) -> IResult<&'a str, T>,
+{
+    separated_nonempty_list(space_opt(char(',')), inner)
+}
+
+/// Parses some input digits to a usize.
+pub(crate) fn usize(input: &str) -> IResult<&str, usize> {
+    map_res(digit1, |s: &str| s.parse::<usize>())(input)
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,10 +9,10 @@
 //! [`nom`]: https://crates.io/crates/nom
 use nom::{
     bytes::complete::tag,
-    character::complete::{char, digit1, space0},
-    combinator::map_res,
+    character::complete::{alphanumeric1, char, digit1, space0},
+    combinator::{map_res, opt},
     multi::separated_nonempty_list,
-    sequence::{delimited, preceded, terminated},
+    sequence::{delimited, preceded, terminated, tuple},
     IResult,
 };
 
@@ -20,13 +20,24 @@ pub mod data;
 pub mod river;
 pub mod streamlet;
 
+/// Parses an identifier.
+fn identifier(input: &str) -> IResult<&str, String> {
+    alphanumeric1(input).map(|(a, b)| (a, b.to_string()))
+}
+
 /// Returns a parser function to parse a Type<_> using the provided `inner`
-/// parser.
-pub(crate) fn r#type<'a, T, F>(name: &'a str, inner: F) -> impl Fn(&'a str) -> IResult<&'a str, T>
+/// parser. This includes an optional identifier.
+pub(crate) fn r#type<'a, T, F>(
+    name: &'a str,
+    inner: F,
+) -> impl Fn(&'a str) -> IResult<&'a str, (Option<String>, T)>
 where
     F: Fn(&'a str) -> IResult<&'a str, T>,
 {
-    preceded(tag(name), delimited(char('<'), inner, char('>')))
+    tuple((
+        opt(terminated(identifier, space_opt(char(':')))),
+        preceded(tag(name), delimited(char('<'), inner, char('>'))),
+    ))
 }
 
 /// Returns a parser function which allow space characters after the provided
@@ -52,4 +63,22 @@ where
 /// Parses some input digits to a usize.
 pub(crate) fn usize(input: &str) -> IResult<&str, usize> {
     map_res(digit1, |s: &str| s.parse::<usize>())(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_identifier() {
+        assert_eq!(identifier("asdf"), Ok(("", "asdf".to_string())));
+        assert_eq!(identifier("asdf asdf"), Ok((" asdf", "asdf".to_string())));
+        assert_eq!(identifier("1234 asdf"), Ok((" asdf", "1234".to_string())));
+    }
+
+    #[test]
+    fn parse_type() {
+        let test = r#type("Test", identifier);
+        assert_eq!(test("Test<a>").unwrap(), ("", (None, "a".to_string())));
+    }
 }

--- a/src/parser/river.rs
+++ b/src/parser/river.rs
@@ -30,7 +30,7 @@ macro_rules! river_group_type_parse_fn {
             map(r#type($name, nonempty_comma_list(river_type)), |x| {
                 $variant {
                     identifier: x.0,
-                    childs: x.1,
+                    children: x.1,
                 }
             })(input)
         }
@@ -210,7 +210,7 @@ mod tests {
                 "",
                 River::Group {
                     identifier: None,
-                    childs: vec![
+                    children: vec![
                         River::Bits {
                             identifier: None,
                             width: 4
@@ -299,7 +299,7 @@ mod tests {
                 "",
                 River::Union {
                     identifier: None,
-                    childs: vec![
+                    children: vec![
                         River::Bits {
                             identifier: None,
                             width: 8

--- a/src/parser/river.rs
+++ b/src/parser/river.rs
@@ -1,0 +1,247 @@
+use crate::{
+    parser::{nonempty_comma_list, r#type, space_opt, usize},
+    River, RiverParameters,
+};
+use nom::{
+    branch::alt,
+    character::complete::char,
+    combinator::{map, opt},
+    sequence::{preceded, tuple},
+    IResult,
+};
+
+macro_rules! river_type_parse_fn {
+    ($ident:ident, $name:expr, $variant:expr) => {
+        pub fn $ident(input: &str) -> IResult<&str, River> {
+            river_type_parser($name, |(river_type, river_parameters)| {
+                $variant(Box::new(river_type), river_parameters.unwrap_or_default())
+            })(input)
+        }
+    };
+}
+
+macro_rules! river_group_type_parse_fn {
+    ($ident:ident, $name:expr, $variant:expr) => {
+        pub fn $ident(input: &str) -> IResult<&str, River> {
+            map(r#type($name, nonempty_comma_list(river_type)), $variant)(input)
+        }
+    };
+}
+
+/// Returns a River type parser.
+#[allow(clippy::needless_lifetimes)] // rust-lang/rust-clippy/issues/2944
+fn river_type_parser<'a, F>(name: &'a str, inner: F) -> impl Fn(&'a str) -> IResult<&'a str, River>
+where
+    F: Fn((River, Option<RiverParameters>)) -> River,
+{
+    map(
+        r#type(
+            name,
+            tuple((
+                river_type,
+                opt(preceded(space_opt(char(',')), river_parameters)),
+            )),
+        ),
+        inner,
+    )
+}
+
+/// Parses a RiverParameters.
+pub fn river_parameters(input: &str) -> IResult<&str, RiverParameters> {
+    map(
+        tuple((
+            usize,
+            opt(space_opt(char(','))),
+            opt(usize),
+            opt(space_opt(char(','))),
+            opt(usize),
+        )),
+        |(elements, _, complexity, _, userbits): (usize, _, Option<usize>, _, Option<usize>)| {
+            RiverParameters {
+                elements: Some(elements),
+                complexity,
+                userbits,
+            }
+        },
+    )(input)
+}
+
+/// Parses a Bits<b>.
+pub fn bits(input: &str) -> IResult<&str, River> {
+    map(r#type("Bits", usize), River::Bits)(input)
+}
+
+river_type_parse_fn!(root, "Root", River::Root);
+river_type_parse_fn!(dim, "Dim", River::Dim);
+river_type_parse_fn!(new, "New", River::New);
+river_type_parse_fn!(rev, "Rev", River::Rev);
+river_group_type_parse_fn!(group, "Group", River::Group);
+river_group_type_parse_fn!(r#union, "Union", River::Union);
+
+/// Parses a River type.
+pub fn river_type(input: &str) -> IResult<&str, River> {
+    alt((r#union, rev, new, dim, group, root, bits))(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RiverParameters;
+
+    #[test]
+    fn parse_river_parameters() {
+        assert_eq!(
+            river_parameters("3, 4, 5"),
+            Ok((
+                "",
+                RiverParameters {
+                    elements: Some(3),
+                    complexity: Some(4),
+                    userbits: Some(5)
+                }
+            ))
+        );
+        assert!(river_parameters("").is_err());
+        assert_eq!(
+            river_parameters("1"),
+            Ok((
+                "",
+                RiverParameters {
+                    elements: Some(1),
+                    complexity: None,
+                    userbits: None
+                }
+            ))
+        );
+        assert_eq!(
+            river_parameters("1,2"),
+            Ok((
+                "",
+                RiverParameters {
+                    elements: Some(1),
+                    complexity: Some(2),
+                    userbits: None
+                }
+            ))
+        );
+        assert_eq!(river_parameters("1,2"), river_parameters("1,2,"));
+        assert_eq!(
+            river_parameters("1,,3"),
+            Ok((
+                "",
+                RiverParameters {
+                    elements: Some(1),
+                    complexity: None,
+                    userbits: Some(3)
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_bits() {
+        assert_eq!(bits("Bits<8>"), Ok(("", River::Bits(8))));
+        assert!(bits("Bits<>").is_err());
+        assert!(bits("bits<8>").is_err());
+    }
+
+    #[test]
+    fn parse_root() {
+        assert_eq!(
+            root("Root<Bits<8>, 1, 2, 3>"),
+            Ok((
+                "",
+                River::Root(
+                    Box::new(River::Bits(8)),
+                    RiverParameters {
+                        elements: Some(1),
+                        complexity: Some(2),
+                        userbits: Some(3)
+                    }
+                )
+            ))
+        );
+        assert_eq!(
+            root("Root<Bits<8>>"),
+            Ok((
+                "",
+                River::Root(Box::new(River::Bits(8)), RiverParameters::default())
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_group() {
+        assert_eq!(
+            group("Group<Bits<4>, Bits<8>>"),
+            Ok(("", River::Group(vec![River::Bits(4), River::Bits(8)])))
+        );
+    }
+
+    #[test]
+    fn parse_dim() {
+        assert_eq!(
+            dim("Dim<Bits<8>, 1, 2, 3>"),
+            Ok((
+                "",
+                River::Dim(
+                    Box::new(River::Bits(8)),
+                    RiverParameters {
+                        elements: Some(1),
+                        complexity: Some(2),
+                        userbits: Some(3)
+                    }
+                )
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_new() {
+        assert_eq!(
+            new("New<Bits<7>, 3, 2, 1>"),
+            Ok((
+                "",
+                River::New(
+                    Box::new(River::Bits(7)),
+                    RiverParameters {
+                        elements: Some(3),
+                        complexity: Some(2),
+                        userbits: Some(1)
+                    }
+                )
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_rev() {
+        assert_eq!(
+            rev("Rev<Bits<8>, 11, 22, 33>"),
+            Ok((
+                "",
+                River::Rev(
+                    Box::new(River::Bits(8)),
+                    RiverParameters {
+                        elements: Some(11),
+                        complexity: Some(22),
+                        userbits: Some(33)
+                    }
+                )
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_union() {
+        assert_eq!(
+            union("Union<Bits<8>, Bits<4>>"),
+            Ok(("", River::Union(vec![River::Bits(8), River::Bits(4)])))
+        );
+    }
+
+    #[test]
+    fn parse_river_type() {
+        assert_eq!(river_type("Bits<8>"), Ok(("", River::Bits(8))));
+    }
+}

--- a/src/parser/streamlet.rs
+++ b/src/parser/streamlet.rs
@@ -52,8 +52,35 @@ Bits<4>"#
             (
                 "",
                 Streamlet {
-                    input: vec![Bits(1), Bits(2)],
-                    output: vec![Group(vec![Bits(3), Bits(4)]), Bits(4)]
+                    input: vec![
+                        Bits {
+                            identifier: None,
+                            width: 1
+                        },
+                        Bits {
+                            identifier: None,
+                            width: 2
+                        }
+                    ],
+                    output: vec![
+                        Group {
+                            identifier: None,
+                            childs: vec![
+                                Bits {
+                                    identifier: None,
+                                    width: 3
+                                },
+                                Bits {
+                                    identifier: None,
+                                    width: 4
+                                }
+                            ]
+                        },
+                        Bits {
+                            identifier: None,
+                            width: 4
+                        }
+                    ]
                 }
             )
         );

--- a/src/parser/streamlet.rs
+++ b/src/parser/streamlet.rs
@@ -65,7 +65,7 @@ d: Bits<4>"#
                     output: vec![
                         Group {
                             identifier: Some("c".to_string()),
-                            childs: vec![
+                            children: vec![
                                 Bits {
                                     identifier: None,
                                     width: 3

--- a/src/parser/streamlet.rs
+++ b/src/parser/streamlet.rs
@@ -1,0 +1,61 @@
+use crate::{parser::river, Streamlet};
+use nom::{
+    character::complete::newline,
+    combinator::map,
+    multi::{many1, separated_nonempty_list},
+    sequence::tuple,
+    IResult,
+};
+
+/// Parses a Streamlet interface definition.
+///
+/// A streamlet interface definition consists of one or more input River types
+/// followed by one or more output River types, separated by a newline.
+///
+/// # Example
+///
+/// ```text
+/// Bits<1>
+/// Bits<2>
+///
+/// Group<Bits<3>, Bits<4>>
+/// Bits<4>
+/// ```
+///
+pub fn streamlet_interface_definition(input: &str) -> IResult<&str, Streamlet> {
+    map(
+        tuple((
+            separated_nonempty_list(newline, river::river_type),
+            many1(newline),
+            separated_nonempty_list(newline, river::river_type),
+        )),
+        |(input, _, output)| Streamlet { input, output },
+    )(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::River::{Bits, Group};
+
+    #[test]
+    fn parse_streamlet_interface_definition() {
+        assert_eq!(
+            streamlet_interface_definition(
+                r#"Bits<1>
+Bits<2>
+
+Group<Bits<3>, Bits<4>>
+Bits<4>"#
+            )
+            .unwrap(),
+            (
+                "",
+                Streamlet {
+                    input: vec![Bits(1), Bits(2)],
+                    output: vec![Group(vec![Bits(3), Bits(4)]), Bits(4)]
+                }
+            )
+        );
+    }
+}

--- a/src/parser/streamlet.rs
+++ b/src/parser/streamlet.rs
@@ -42,11 +42,11 @@ mod tests {
     fn parse_streamlet_interface_definition() {
         assert_eq!(
             streamlet_interface_definition(
-                r#"Bits<1>
-Bits<2>
+                r#"a: Bits<1>
+b: Bits<2>
 
-Group<Bits<3>, Bits<4>>
-Bits<4>"#
+c: Group<Bits<3>, Bits<4>>
+d: Bits<4>"#
             )
             .unwrap(),
             (
@@ -54,17 +54,17 @@ Bits<4>"#
                 Streamlet {
                     input: vec![
                         Bits {
-                            identifier: None,
+                            identifier: Some("a".to_string()),
                             width: 1
                         },
                         Bits {
-                            identifier: None,
+                            identifier: Some("b".to_string()),
                             width: 2
                         }
                     ],
                     output: vec![
                         Group {
-                            identifier: None,
+                            identifier: Some("c".to_string()),
                             childs: vec![
                                 Bits {
                                     identifier: None,
@@ -77,7 +77,7 @@ Bits<4>"#
                             ]
                         },
                         Bits {
-                            identifier: None,
+                            identifier: Some("d".to_string()),
                             width: 4
                         }
                     ]


### PR DESCRIPTION
This adds the `parser` module (behind the `parser` feature flag) with parsers for `Data`, `River` and `Streamlet` types, built using parser combinators.