### PR TITLE
Update book workflow trigger

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,8 @@ on:
     branches:
     - master
   pull_request:
+    paths:
+    - 'book/**'
 
 jobs:
   build:


### PR DESCRIPTION
The book workflow should only trigger when changes are made in the `book` path.