### PR TITLE
Add spec introduction, restructure spec

### DIFF
--- a/book/src/README.md
+++ b/book/src/README.md
@@ -5,33 +5,15 @@
 Tydi is an open-source project that aims to standardize interfaces for 
 hardware components used in modern streaming dataflow designs.
 
-The project consists of two parts: a set of *specifications* and a set of 
+The project consists of two parts: the Tydi specification and a set of 
 reference implementations of useful tools.
 
 ## Specification
 
-Tydi contains a set of three specifications for the following, related 
-concepts:
-
-1. [Physical streams](./specification/physical.md)
-2. [Logical streams](./specification/logical.md) (under construction)
-3. [Streamlets](./specification/streamlet.md) (under construction)
-
-**Physical streams** are hardware streams with their own valid/ready 
-handshaking interface, transporting elementary data. Their exact bit-level 
-representation and transfer behavior is defined through five parameters. 
-These parameters are derived from logical streams.
-
-**Logical streams** are one or multiple physical streams of some type from 
-the Tydi type system. Types expressed in this type system determine which 
-physical streams with which parameters make up the logical stream.
-
-**Streamlets** are components that have Tydi logical streams as input and 
-output.
-
-The Tydi type system for logical streams allows the expression of data types 
-that represent *dynamically-sized, nested and multidimensional data 
-structures* in hardware.
+The Tydi (Typed dataflow interface) specification is at the core of the
+project: it defines what an interface should look like and constrains its
+behavior, based on a constructively defined, low-level data type. Start
+reading [here](./specification/index.md).
 
 ## Tools
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,9 +6,9 @@
 
 - [Introduction](./README.md)
 - [Specification](./specification/README.md)
-  - [Physical stream](./specification/physical.md)
-  - [Logical stream](./specification/logical.md)
-  - [Streamlet](./specification/streamlet.md)
+  - [Introduction](./specification/intro.md)
+  - [Physical streams](./specification/physical.md)
+  - [Logical streams](./specification/logical.md)
 - [Tools](./tools/README.md)
   - [Generators](./tools/generators.md)
   - [Compositors](./tools/compositors.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,7 +5,7 @@
 ---
 
 - [Introduction](./README.md)
-- [Specification](./specification/README.md)
+- [Tydi specification](./specification/README.md)
   - [Introduction](./specification/intro.md)
   - [Physical streams](./specification/physical.md)
   - [Logical streams](./specification/logical.md)

--- a/book/src/introduction/introduction.md
+++ b/book/src/introduction/introduction.md
@@ -1,1 +1,0 @@
-# Introduction

--- a/book/src/specification/README.md
+++ b/book/src/specification/README.md
@@ -1,1 +1,27 @@
-# Specification
+Tydi specification
+==================
+
+The Tydi specification, short for Typed dataflow interface specification,
+aims to provide a standardized way in which complex data types can be
+transferred from one circuit to another, within the context of FPGAs or
+ASICs.
+
+How to read this document
+-------------------------
+
+The specification is comprised of the following sections.
+
+ - [Introduction](intro.md): defines the motivation and scope of this
+   specification.
+ - [Physical stream specification](physical.md): defines physical streams,
+   carrying a stream of data and dimensionality information.
+ - [Logical stream specification](logical.md): defines the building blocks
+   for transferring complex data types by means of one or more physical
+   streams.
+
+The two specification sections are written such that the first paragraph of
+each section *defines* a new concept, and the subsequent paragraphs *constrain*
+it.
+
+> Additional information, such as examples, a more intuitive description, or
+> motivation, is written in these kinds of blocks.

--- a/book/src/specification/README.md
+++ b/book/src/specification/README.md
@@ -13,11 +13,19 @@ The specification is comprised of the following sections.
 
  - [Introduction](intro.md): defines the motivation and scope of this
    specification.
- - [Physical stream specification](physical.md): defines physical streams,
-   carrying a stream of data and dimensionality information.
- - [Logical stream specification](logical.md): defines the building blocks
-   for transferring complex data types by means of one or more physical
-   streams.
+
+ - [Physical stream specification](physical.md). **Physical streams** are
+   hardware streams with their own valid/ready handshaking interface,
+   transporting elementary data and dimensionality information. Their exact
+   bit-level representation and transfer behavior is defined through five
+   parameters. These parameters are normally derived from logical streams.
+
+ - [Logical stream specification](logical.md). **Logical streams** are bundles
+   of one or multiple physical streams of some type from the Tydi type system.
+   Types expressed in this type system determine which physical streams with
+   which parameters make up the logical stream. This section also introduces
+   **streamlets**, the Tydi name for components that have logical streams as
+   inputs and/or outputs.
 
 The two specification sections are written such that the first paragraph of
 each section *defines* a new concept, and the subsequent paragraphs *constrain*

--- a/book/src/specification/intro.md
+++ b/book/src/specification/intro.md
@@ -42,7 +42,8 @@ certain FPGA device family.
 
 This situation has given rise to a number of open-source projects that take
 higher-level languages and transform them to vendor-agnostic VHDL or Verilog.
-Examples of this are Chisel/FIRRTL and Clash, using generative Scala code and a
+Examples of this are [Chisel/FIRRTL](https://www.chisel-lang.org/) and
+[Clash](https://clash-lang.org/), using generative Scala code and a
 Haskell-like functional programming language as their respective inputs. Both
 tools come with their own standard libraries of hardware components that can be
 used to compose accelerators out of smaller primitives, similar to the data
@@ -53,9 +54,11 @@ With the advent of these data flow composition tools, it is increasingly
 important to have a common interface standard to allow the primitive blocks to
 connect to each other. The de-facto standard for this has become the AMBA AXI4
 interface, designed by ARM for their microcontrollers and processors. Roughly
-speaking, AXI4 specifies an interface for device-to-memory connections (AXI4
-and AXI4-lite), and a streaming interface (AXI4-stream) for intra-device
-connections.
+speaking, AXI4 specifies an interface for device-to-memory connections
+([AXI4 and AXI4-lite](https://static.docs.arm.com/ihi0022/d/IHI0022D_amba_axi_protocol_spec.pdf)),
+and a streaming interface
+([AXI4-stream](https://static.docs.arm.com/ihi0051/a/IHI0051A_amba4_axi4_stream_v1_0_protocol_spec.pdf))
+for intra-device connections.
 
 While AXI4 and AXI4-lite are of primary importance to processors due to their
 memory-oriented nature, AXI4-stream is much more important for FPGAs due to
@@ -87,17 +90,19 @@ representation to another for any communication between the two components.
 This serialization and deserialization overhead can and often does cost more
 CPU time than the execution of the algorithms themselves.
 
-The Apache Arrow project attempts to solve this problem by standardizing a way
-to represent this abstract data in memory, and providing libraries for popular
-programming languages to interact with this data format. The goal is to make
-transferring data between two processes as efficient as sharing a pool of
-Arrow-formatted memory between them. Arrow also specifies efficient ways of
-serializing Arrow data structures for (temporary) storage in files or streaming
-structures over a network, and can also be used by GPUs through CUDA. However,
-FPGA-based acceleration is at the time of writing missing from the core
-project. The Fletcher project attempts to bridge this gap, by providing an
-interface layer between the Arrow in-memory format and FPGA accelerators,
-presenting the memory to the accelerator in an abstract, tabular form.
+The [Apache Arrow](https://arrow.apache.org/) project attempts to solve this
+problem by standardizing a way to represent this abstract data in memory, and
+providing libraries for popular programming languages to interact with this
+data format. The goal is to make transferring data between two processes as
+efficient as sharing a pool of Arrow-formatted memory between them. Arrow also
+specifies efficient ways of serializing Arrow data structures for (temporary)
+storage in files or streaming structures over a network, and can also be used
+by GPUs through CUDA. However, FPGA-based acceleration is at the time of
+writing missing from the core project. The
+[Fletcher](https://github.com/abs-tudelft/fletcher) project attempts to bridge
+this gap, by providing an interface layer between the Arrow in-memory format
+and FPGA accelerators, presenting the memory to the accelerator in an abstract,
+tabular form.
 
 In order to represent the complex, nested data types supported by Arrow, the
 Fletcher project had to devise its own data streaming format on top of the
@@ -141,8 +146,10 @@ Non-goals
    NOT mean streaming over existing communication formats such as Ethernet, and
    certainly not over abstract streams such as POSIX pipes or other
    inter-process communication paradigms. If you're looking for the former,
-   have a look at Arrow Flight. The latter is part of Apache Arrow itself
-   through their IPC format specification.
+   have a look at
+   [Arrow Flight](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/).
+   The latter is part of Apache Arrow itself through their
+   [IPC format specification](https://arrow.apache.org/docs/ipc.html).
 
  - We do not intend to compete with the AXI4(-stream) specification.
    AXI4-stream is designed for streaming unstructured byte-oriented data;

--- a/book/src/specification/intro.md
+++ b/book/src/specification/intro.md
@@ -1,0 +1,157 @@
+Introduction
+============
+
+This section describes the motivation and scope of the Tydi specification.
+
+Background and motivation
+-------------------------
+
+As FPGAs become faster and larger, they are increasingly used within a
+data center context to accelerate computational workloads. FPGAs can already
+achieve greater compute density and power efficiency than CPUs and GPUs for
+certain types of workloads, particularly those that rely on high streaming
+throughput and branch-heavy computation. Examples of this are decompression,
+SQL query acceleration, and pattern matching. The major disadvantage of FPGAs
+is that they are more difficult to program than CPUs and GPUs, and that
+algorithms expressed imperatively in the CPU/GPU domain often need to be
+redesigned from the ground up to achieve competitive performance. Both the
+advantages and disadvantages are due to the spatial nature of an FPGA: instead
+of programming a number of processors, an FPGA designer "programs" millions of
+basic computational elements not much more complex than a single logic gate
+that all work parallel to each other, and describes how these elements are
+interconnected. This extreme programmability comes at a cost of roughly an
+order of magnitude in area and an order of magnitude in performance compared
+to the custom silicon used to make CPUs and GPUs. Therefore, while imperative
+algorithms can indeed be mapped to FPGAs more or less directly through
+high-level synthesis (HLS) techniques or the use of softcores, typically an
+algorithm needs at least two orders of magnitude of acceleration through clever
+use of the spatial nature of the FPGA to be competitive.
+
+Unfortunately, the industry-standard toolchains needed to program FPGAs only
+take VHDL, Verilog, SystemC, (more recently through HLS) a subset of C++,
+and/or visually designed data flow graphs as their input. The first three
+provide few abstractions above the level of a single wire: while they do allow
+the use of data types such as integers and structures to represent bundles of
+wires, all control of what the voltages on those bundles of wires represent at
+a certain point in time (if anything) remains up to the programmer. The latter
+two techniques raise the bar slightly by presenting the designer with streams
+and memory. However, they are vendor-specific, often require additional
+licensing fees over the more traditional design entry methods, and in some
+cases are even specific to a certain version of the vendor tool and/or a
+certain FPGA device family.
+
+This situation has given rise to a number of open-source projects that take
+higher-level languages and transform them to vendor-agnostic VHDL or Verilog.
+Examples of this are Chisel/FIRRTL and Clash, using generative Scala code and a
+Haskell-like functional programming language as their respective inputs. Both
+tools come with their own standard libraries of hardware components that can be
+used to compose accelerators out of smaller primitives, similar to the data
+flow design method described earlier, but with textual input and the advantage
+of being vendor and device agnostic.
+
+With the advent of these data flow composition tools, it is increasingly
+important to have a common interface standard to allow the primitive blocks to
+connect to each other. The de-facto standard for this has become the AMBA AXI4
+interface, designed by ARM for their microcontrollers and processors. Roughly
+speaking, AXI4 specifies an interface for device-to-memory connections (AXI4
+and AXI4-lite), and a streaming interface (AXI4-stream) for intra-device
+connections.
+
+While AXI4 and AXI4-lite are of primary importance to processors due to their
+memory-oriented nature, AXI4-stream is much more important for FPGAs due to
+their spatial nature. However, because AXI4-stream is not originally designed
+for FPGAs, parts of the specifications are awkward for this purpose. For
+instance, AXI4-stream is byte oriented: it requires its data signal to be
+divided into one or more byte lanes, and specifies (optional) control signals
+that indicate the significance of each lane. Since FPGA designs are not at all
+restricted to operating on byte elements, this part of the specification is
+often ignored, and as such, any stream with a `valid`, `ready`, and one or more
+`data` signals of any width has become the de-facto streaming standard. This is
+reflected for instance by Chisel's built-in `Decoupled` interface type.
+
+Within a single design this is of course not an issue — as long as both the
+stream source and sink blocks agree on the same noncompliant interface, the
+design will work. However, bearing in mind that there is an increasing number
+of independently developed data flow oriented tools, each with their own
+standard library, interoperability becomes an issue: whenever a designer needs
+to use components from different vendors, they must first ensure that the
+interfaces match, and if not, insert the requisite glue logic in between.
+
+A similar issue exists in the software domain, where different programming
+languages use different runtime environments and calling conventions. For
+instance, efficiently connecting a component written in Java to a component
+written in Python requires considerable effort. The keyword here is
+"efficiently:" because Java and Python have very different ways of representing
+abstract data in memory, one fundamentally has to convert from one
+representation to another for any communication between the two components.
+This serialization and deserialization overhead can and often does cost more
+CPU time than the execution of the algorithms themselves.
+
+The Apache Arrow project attempts to solve this problem by standardizing a way
+to represent this abstract data in memory, and providing libraries for popular
+programming languages to interact with this data format. The goal is to make
+transferring data between two processes as efficient as sharing a pool of
+Arrow-formatted memory between them. Arrow also specifies efficient ways of
+serializing Arrow data structures for (temporary) storage in files or streaming
+structures over a network, and can also be used by GPUs through CUDA. However,
+FPGA-based acceleration is at the time of writing missing from the core
+project. The Fletcher project attempts to bridge this gap, by providing an
+interface layer between the Arrow in-memory format and FPGA accelerators,
+presenting the memory to the accelerator in an abstract, tabular form.
+
+In order to represent the complex, nested data types supported by Arrow, the
+Fletcher project had to devise its own data streaming format on top of the
+de-facto subset of AXI4-stream. Originally, this format was simply a means
+to an end, and therefore, not much thought was put into it. Particularly, as
+only Arrow-to-device interfaces (and back) were needed for the project, an
+interface designed specifically for intra-device streaming is lacking; in
+fact, depending on configuration, the reader and writer interfaces do not even
+match completely. Clearly, a standard for streaming complex data types between
+components is needed, both within the context of the Fletcher project, and
+outside of it.
+
+As far as the writers are aware, no such standard exists as of yet. Defining
+such a standard in an open, royalty-free way is the primary purpose of this
+document.
+
+Goals
+-----
+
+ - Defining a streaming format for complex data types in the context of FPGAs
+   and, potentially, ASICs, where "complex data types" include:
+
+    * multi-dimensional sequences of undefined length;
+    * unions (a.k.a. variants);
+    * structures such as tuples or records.
+
+ - Doing the above in as broad of a way as possible, without imposing
+   unnecessary burdens on the development of simpler components.
+
+ - Allowing for minimization of area and complexity through well-defined
+   contracts between source and sink on top of the signal specification itself.
+
+ - Extensibility: this specification should be as usable as possible, even to
+   those with use cases not foreseen by this specification.
+
+Non-goals
+---------
+
+ - In this specification, a "streaming format" refers to the way in which the
+   voltages on a bundle of wires are used to communicate data. We expressly do
+   NOT mean streaming over existing communication formats such as Ethernet, and
+   certainly not over abstract streams such as POSIX pipes or other
+   inter-process communication paradigms. If you're looking for the former,
+   have a look at Arrow Flight. The latter is part of Apache Arrow itself
+   through their IPC format specification.
+
+ - We do not intend to compete with the AXI4(-stream) specification.
+   AXI4-stream is designed for streaming unstructured byte-oriented data;
+   Tydi streams are for streaming structured, complex data types.
+
+ - Tydi streams have no notion of multi-endpoint network-on-chip-like
+   structures. Adding source and destination addressing or other routing
+   information can be done through the `user` signal.
+
+ - The primitive data type in Tydi is a group of bits. We leave the mapping
+   from these bits to higher-order types such as numbers, characters, or
+   timestamps to existing specifications.

--- a/book/src/specification/intro.md
+++ b/book/src/specification/intro.md
@@ -125,7 +125,7 @@ Goals
     * structures such as tuples or records.
 
  - Doing the above in as broad of a way as possible, without imposing
-   unnecessary burdens on the development of simpler components.
+   unnecessary burdens on the development of simple components.
 
  - Allowing for minimization of area and complexity through well-defined
    contracts between source and sink on top of the signal specification itself.

--- a/book/src/specification/logical.md
+++ b/book/src/specification/logical.md
@@ -1,3 +1,3 @@
-# Logical stream specification
+# Logical streams
 
 (under construction)

--- a/book/src/specification/physical.md
+++ b/book/src/specification/physical.md
@@ -1,5 +1,5 @@
-Physical stream specification
-=============================
+Physical streams
+================
 
 A Tydi physical stream carries a stream of elements, dimensionality information
 for said elements, and (optionally) user-defined transfer information from a

--- a/book/src/specification/streamlet.md
+++ b/book/src/specification/streamlet.md
@@ -1,3 +1,1 @@
 # Streamlet
-
-(under construction)


### PR DESCRIPTION
In the interest of incremental updates, we might want to merge this already so it looks a bit more finished until the logical stream spec is complete.

Removed the streamlet specification as discussed; there wouldn't be much to specify here, since a streamlet is just a component with one or more logical streams going in and out. I could maybe add it at the bottom of the logical spec section though.