### PR TITLE
Fix book navigation issue

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,9 +1,5 @@
 # Summary
 
-[Tydi](./README.md)
-
----
-
 - [Introduction](./README.md)
 - [Tydi specification](./specification/README.md)
   - [Introduction](./specification/intro.md)


### PR DESCRIPTION
I noticed that with the current setup of the book the next (>) navigation is broken for the Tydi and Introduction chapter. Since they both point to the same file (which is probably the cause of this issue), I removed the top item.