### PR TITLE
Fix a typo in the union example

### DIFF
--- a/book/src/specification/logical.md
+++ b/book/src/specification/logical.md
@@ -600,7 +600,7 @@ stream as defined by the \\(s\\) parameter of the child stream.
 >
 > \\[B = \textrm{Group}(x: \textrm{Bits}(2), y: \textrm{Bits}(2))\\\\
 > C = \textrm{Stream}(d=1, s=x, T_e=\textrm{Bits}(4))\\\\
-> U = \textrm{Union}(\textrm{a} : \textrm{Bits}(3), \textrm{b} : \textrm{Bits}(3), \textrm{c} : C)\\\\
+> U = \textrm{Union}(\textrm{a} : \textrm{Bits}(3), \textrm{b} : \textrm{B}, \textrm{c} : C)\\\\
 > \textrm{Stream}(d=1, T_e=U)\\]
 >
 > This results in two physical streams:


### PR DESCRIPTION
Was writing a test and noticed that `B` was unused. However the example data: `[a:0, b:(x:1, y:2)], [c:[3, 4, 5], a:6]` shows this group is used there with the `b` name.