### PR TITLE
Implement converters from Tydi world to common structural representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tydi"
 version = "0.0.0"
-description = "A code generation utility for hardware described using Tydi"
+description = "An HDL code generation utility for components described using the Tydi open specification."
 authors = ["Johan Peltenburg", "Jeroen van Straten", "Matthijs Brobbel"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/design/library.rs
+++ b/src/design/library.rs
@@ -19,7 +19,7 @@ pub struct Library {
 }
 
 impl crate::traits::Identify for Library {
-    fn name(&self) -> &str {
+    fn identifier(&self) -> &str {
         self.name.as_ref()
     }
 }
@@ -59,7 +59,7 @@ impl Library {
             .map_err(|e| ParsingError(e.to_string()))?
             .1;
             debug!("Parsed streamlets: {}", {
-                let sln: Vec<&str> = streamlets.iter().map(|s| s.name()).collect();
+                let sln: Vec<&str> = streamlets.iter().map(|s| s.identifier()).collect();
                 sln.join(", ")
             });
             Library::from_builder(

--- a/src/design/project.rs
+++ b/src/design/project.rs
@@ -11,7 +11,7 @@ pub struct Project {
 }
 
 impl crate::traits::Identify for Project {
-    fn name(&self) -> &str {
+    fn identifier(&self) -> &str {
         self.name.as_ref()
     }
 }

--- a/src/design/streamlet.rs
+++ b/src/design/streamlet.rs
@@ -29,14 +29,17 @@ impl Streamlet {
 }
 
 impl crate::traits::Identify for Streamlet {
-    fn name(&self) -> &str {
+    fn identifier(&self) -> &str {
         self.name.as_ref()
     }
 }
 
+/// Streamlet interface mode.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Mode {
+    /// The interface is an output of the streamlet.
     Out,
+    /// The interface is an input of the streamlet.
     In,
 }
 
@@ -73,7 +76,7 @@ impl Interface {
 }
 
 impl crate::traits::Identify for Interface {
-    fn name(&self) -> &str {
+    fn identifier(&self) -> &str {
         self.name.as_ref()
     }
 }

--- a/src/generator/chisel/mod.rs
+++ b/src/generator/chisel/mod.rs
@@ -34,7 +34,7 @@ pub struct ChiselBackEnd {
 
 #[allow(unused_variables)]
 impl GenerateProject for ChiselBackEnd {
-    fn generate(&self, project: &Project, path: &Path) -> Result<()> {
+    fn generate(&self, project: &Project, path: impl AsRef<Path>) -> Result<()> {
         unimplemented!();
     }
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -267,17 +267,16 @@ impl Componentify for Streamlet {
         Some(Component {
             identifier: self.identifier().to_string(),
             parameters: vec![],
-            ports: {
-                // TODO(johanpel): rust lords make me a flatmap
-                let mut all_ports = Vec::new();
-                self.interfaces().into_iter().for_each(|interface| {
-                    all_ports.extend(interface.user(
-                        interface.identifier(),
-                        cat!(self.identifier().to_string(), interface.identifier()),
-                    ));
-                });
-                all_ports
-            },
+            ports: self
+            .interfaces()
+            .into_iter()
+            .flat_map(|interface| {
+                interface.user(
+                interface.identifier(),
+                cat!(self.identifier().to_string(), interface.identifier()),
+                        )
+                    })
+                    .collect(),
         })
     }
 

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -4,14 +4,38 @@
 
 use std::path::Path;
 
+use crate::design::{Interface, Streamlet};
 use crate::generator::common::{Component, Library, Mode, Port, Project, Record, Type};
-use crate::physical::PhysicalStream;
+use crate::logical::{Group, LogicalStreamType, Stream};
+use crate::physical::{Origin, Signal, Width};
 use crate::traits::Identify;
 use crate::Result;
 
 pub mod chisel;
 pub mod common;
 pub mod vhdl;
+
+/// Concatenate stuff using format with an underscore in between.
+/// Useful if the separator ever changes.
+
+#[macro_export]
+macro_rules! cat {
+    ($a:expr) => {{
+        format!("{}", $a)
+    }};
+
+    ($a:expr, $($b:expr),+) => {{
+        let left : String = format!("{}", $a);
+        let right : String = format!("{}", cat!($($b),+));
+        if left == "" {
+            right
+        } else if right == "" {
+            left
+        } else {
+            format!("{}_{}", left, right)
+        }
+    }};
+}
 
 /// Trait to generate back-end specific source files from the common hardware representation
 /// of a project.
@@ -20,26 +44,212 @@ pub trait GenerateProject {
     fn generate(&self, project: &Project, path: &Path) -> Result<()>;
 }
 
-pub trait Synthesize {
-    fn synthesize(&self, prefix: impl Into<String>) -> Type;
+/// Trait to create common representation types from things in the canonical
+/// way and user-friendly way.
+pub trait Typify {
+    fn user(&self, _prefix: impl Into<String>) -> Option<Type> {
+        None
+    }
+    fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal>;
 }
 
-impl Synthesize for PhysicalStream {
-    fn synthesize(&self, prefix: impl Into<String>) -> Type {
-        // Creates a common HW representation type from a physical `Stream` according to
-        // Tydi specification.
-        let mut rec = Record::empty(prefix.into());
+/// Trait to create common representation ports from things in the canonical
+/// way and user-friendly way.
+pub trait Portify {
+    fn user(
+        &self,
+        _port_name: impl Into<String>,
+        _port_type_prefix: impl Into<String>,
+    ) -> Vec<Port> {
+        Vec::new()
+    }
+    fn canonical(&self, name: impl Into<String>) -> Vec<Port>;
+}
 
-        // Valid/Ready handshake ports
-        rec.add_field("valid", Type::Bit);
-        rec.add_field_rev("ready", Type::Bit);
+/// Trait to create common representation components from things in the canonical
+/// way and user-friendly way.
+pub trait Componentify {
+    fn user(&self, _name: impl Into<String>) -> Option<Component> {
+        None
+    }
+    fn canonical(&self, name: impl Into<String>) -> Component;
+}
 
-        // Iterate over signal map.
-        for (name, width) in self.signal_map().into_iter() {
-            rec.add_field(name, Type::bitvec(width));
+impl Typify for LogicalStreamType {
+    /// This implementation for LogicalStreamType assumes the LogicalStreamType has already been
+    /// flattened through synthesize.
+    fn user(&self, prefix: impl Into<String>) -> Option<Type> {
+        match self {
+            LogicalStreamType::Bits(width) => Some(Type::bitvec(width.get())),
+            LogicalStreamType::Group(group) => group.user(prefix),
+            LogicalStreamType::Stream(stream) => stream.user(prefix),
+            _ => todo!(),
+        }
+    }
+
+    fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal> {
+        match self {
+            LogicalStreamType::Bits(width) => {
+                vec![Signal::vec(prefix.into(), Origin::Source, *width)]
+            }
+            LogicalStreamType::Group(group) => group.canonical(prefix),
+            LogicalStreamType::Stream(stream) => stream.canonical(prefix),
+            _ => todo!(),
+        }
+    }
+}
+
+impl Typify for Group {
+    fn user(&self, prefix: impl Into<String>) -> Option<Type> {
+        let n: String = prefix.into();
+        let mut rec = Record::new_empty(cat!(n.clone(), "type"));
+        for (field_name, field_logical) in self.iter() {
+            if let Some(field_common_type) = field_logical.user(cat!(n.clone(), field_name)) {
+                rec.insert_field(field_name, field_common_type, false)
+            }
+        }
+        Some(Type::Record(rec))
+    }
+
+    fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal> {
+        let n: String = prefix.into();
+        let mut result = Vec::new();
+        for (field_name, field_logical) in self.iter() {
+            let field_result = field_logical.canonical(cat!(n.clone(), field_name));
+            result.extend(field_result);
+        }
+        result
+    }
+}
+
+impl Typify for Stream {
+    fn user(&self, prefix: impl Into<String>) -> Option<Type> {
+        // We need to wrap the Stream back into a LogicalStreamType
+        // to be able to use various methods for checks and synthesize.
+        let logical = LogicalStreamType::from(self.clone());
+
+        // At this point, it should not be possible that this is a
+        // non-element-only LogicalStreamType.
+        assert!(logical.is_element_only());
+
+        // Check if the logical stream is null.
+        if !logical.is_null() {
+            // Synthesize the logical stream into physical streams.
+            let synth = logical.synthesize();
+
+            // Obtain the path name and signal map from the physical stream.
+            // There should only be one, since it is an element only stream.
+            // Therefore, it should be safe to unwrap.
+            let (name, physical) = synth.streams().next().unwrap();
+            let signals = physical.signal_list();
+
+            // Set up the resulting record.
+            let mut rec = Record::new_empty_stream(match name.len() {
+                0 => cat!(prefix.into(), "type"),
+                _ => cat!(prefix.into(), name, "type"),
+            });
+
+            // Insert data record. There must be something there since it is not null.
+            rec.insert_field("data", self.data().user("data").unwrap(), false);
+
+            // Check signals related to dimensionality, complexity, etc.
+            if let Some(sig) = signals.last() {
+                rec.insert_field("last", sig.width().into(), sig.reversed());
+            }
+            if let Some(sig) = signals.stai() {
+                rec.insert_field("stai", sig.width().into(), sig.reversed());
+            }
+            if let Some(sig) = signals.endi() {
+                rec.insert_field("endi", sig.width().into(), sig.reversed());
+            }
+            if let Some(sig) = signals.strb() {
+                rec.insert_field("strb", sig.width().into(), sig.reversed());
+            }
+
+            Some(Type::Record(rec))
+        } else {
+            None
+        }
+    }
+
+    fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal> {
+        let n: String = prefix.into();
+        let mut result = Vec::new();
+
+        let logical = LogicalStreamType::from(self.clone());
+        assert!(logical.is_element_only());
+        if !logical.is_null() {
+            let synth = logical.synthesize();
+            let (path, phys) = synth.streams().next().unwrap();
+            for signal in phys.signal_list().into_iter() {
+                let n = cat!(n.clone(), path, signal.identifier());
+                result.push(signal.with_name(n));
+            }
         }
 
-        Type::Record(rec)
+        result
+    }
+}
+
+impl From<Width> for Type {
+    fn from(width: Width) -> Self {
+        match width {
+            Width::Scalar => Type::Bit,
+            Width::Vector(w) => Type::bitvec(w),
+        }
+    }
+}
+
+/// Trait that helps to determine the common representation port mode given a streamlet interface
+/// mode.
+pub trait ModeFor {
+    fn mode_for(&self, streamlet_mode: crate::design::Mode) -> Mode;
+}
+
+impl ModeFor for Origin {
+    fn mode_for(&self, streamlet_mode: crate::design::Mode) -> Mode {
+        match self {
+            Origin::Sink => match streamlet_mode {
+                crate::design::Mode::In => Mode::Out,
+                crate::design::Mode::Out => Mode::In,
+            },
+            Origin::Source => match streamlet_mode {
+                crate::design::Mode::In => Mode::In,
+                crate::design::Mode::Out => Mode::Out,
+            },
+        }
+    }
+}
+
+impl Portify for Interface {
+    fn user(&self, name: impl Into<String>, type_name: impl Into<String>) -> Vec<Port> {
+        let n: String = name.into();
+        let tn: String = type_name.into();
+
+        let mut result = Vec::new();
+
+        // Split the LogicalStreamType up into discrete, simple streams.
+        for (path, simple_stream) in self.typ().split().streams() {
+            if let Some(typ) = simple_stream.user(cat!(tn.clone(), path)) {
+                result.push(Port::new(cat!(n.clone(), path), self.mode().into(), typ));
+            }
+        }
+
+        result
+    }
+
+    fn canonical(&self, prefix: impl Into<String>) -> Vec<Port> {
+        let signals = self.typ().canonical(prefix.into());
+        signals
+            .iter()
+            .map(|s| {
+                Port::new(
+                    s.identifier(),
+                    s.origin().mode_for(self.mode()),
+                    s.width().into(),
+                )
+            })
+            .collect()
     }
 }
 
@@ -52,34 +262,35 @@ impl From<crate::design::Mode> for Mode {
     }
 }
 
-impl From<crate::design::Interface> for Vec<Port> {
-    fn from(i: crate::design::Interface) -> Self {
-        i.typ()
-            .synthesize()
-            .streams()
-            .map(|(n, p)| {
-                Port::new(
-                    format!("{}{}", i.name(), n.to_string()),
-                    i.mode().into(),
-                    p.synthesize(format!("{}_{}", i.name(), "rec")),
-                )
-            })
-            .collect()
-    }
-}
-
-impl From<crate::design::Streamlet> for Component {
-    fn from(s: crate::design::Streamlet) -> Self {
-        Component {
-            identifier: s.name().to_string(),
+impl Componentify for Streamlet {
+    fn user(&self, _: impl Into<String>) -> Option<Component> {
+        Some(Component {
+            identifier: self.identifier().to_string(),
             parameters: vec![],
             ports: {
-                let mut ports = Vec::new();
-                s.interfaces().into_iter().for_each(|i| {
-                    let vp: Vec<Port> = i.into();
-                    ports.extend(vp);
+                // TODO(johanpel): rust lords make me a flatmap
+                let mut all_ports = Vec::new();
+                self.interfaces().into_iter().for_each(|interface| {
+                    all_ports.extend(interface.user(
+                        interface.identifier(),
+                        cat!(self.identifier().to_string(), interface.identifier()),
+                    ));
                 });
-                ports
+                all_ports
+            },
+        })
+    }
+
+    fn canonical(&self, _: impl Into<String>) -> Component {
+        Component {
+            identifier: self.identifier().to_string(),
+            parameters: vec![],
+            ports: {
+                let mut all_ports = Vec::new();
+                self.interfaces().into_iter().for_each(|interface| {
+                    all_ports.extend(interface.canonical(interface.identifier()));
+                });
+                all_ports
             },
         }
     }
@@ -88,8 +299,13 @@ impl From<crate::design::Streamlet> for Component {
 impl From<crate::design::Library> for Library {
     fn from(l: crate::design::Library) -> Self {
         Library {
-            identifier: l.name().to_string(),
-            components: l.streamlets().into_iter().map(|s| s.into()).collect(),
+            identifier: l.identifier().to_string(),
+            components: l
+                .streamlets()
+                .into_iter()
+                .map(|s| s.user(s.identifier()))
+                .filter_map(|s| s)
+                .collect(),
         }
     }
 }
@@ -97,7 +313,7 @@ impl From<crate::design::Library> for Library {
 impl From<crate::design::Project> for Project {
     fn from(p: crate::design::Project) -> Self {
         Project {
-            identifier: p.name().to_string(),
+            identifier: p.identifier().to_string(),
             libraries: p.libraries().into_iter().map(|l| l.into()).collect(),
         }
     }
@@ -105,81 +321,279 @@ impl From<crate::design::Project> for Project {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::*;
     use crate::design::{Interface, Streamlet};
-    use crate::generator::common::{Component, Mode, Port};
+    use crate::generator::common::test::records;
     use crate::generator::vhdl::Declare;
-    use crate::generator::Synthesize;
-    use crate::physical::PhysicalStream;
-    use crate::{Name, Result, UniquelyNamedBuilder};
+    use crate::logical::tests::{elements, streams};
+    use crate::{Name, Positive, UniquelyNamedBuilder};
+
+    #[test]
+    fn test_cat() {
+        assert_eq!(cat!("ok"), "ok");
+        assert_eq!(cat!("ok", "tydi"), "ok_tydi");
+        assert_eq!(cat!("ok", "tydi", ""), "ok_tydi");
+        assert_eq!(cat!("", ""), "");
+    }
+
+    mod canonical {
+        use super::*;
+
+        #[test]
+        fn logical_to_common_prim() {
+            let typ = elements::prim(8).canonical("test");
+            assert_eq!(
+                typ,
+                vec![Signal::vec(
+                    "test".to_string(),
+                    Origin::Source,
+                    Positive::new(8).unwrap()
+                )]
+            )
+        }
+
+        #[test]
+        fn logical_to_common_groups() {
+            let typ0 = elements::group().canonical("test");
+            assert_eq!(
+                typ0,
+                vec![
+                    Signal::vec(
+                        "test_a".to_string(),
+                        Origin::Source,
+                        Positive::new(42).unwrap()
+                    ),
+                    Signal::vec(
+                        "test_b".to_string(),
+                        Origin::Source,
+                        Positive::new(1337).unwrap()
+                    )
+                ]
+            );
+
+            let typ1 = elements::group_nested().canonical("test");
+            assert_eq!(
+                typ1,
+                vec![
+                    Signal::vec(
+                        "test_c_a".to_string(),
+                        Origin::Source,
+                        Positive::new(42).unwrap()
+                    ),
+                    Signal::vec(
+                        "test_c_b".to_string(),
+                        Origin::Source,
+                        Positive::new(1337).unwrap()
+                    ),
+                    Signal::vec(
+                        "test_d_a".to_string(),
+                        Origin::Source,
+                        Positive::new(42).unwrap()
+                    ),
+                    Signal::vec(
+                        "test_d_b".to_string(),
+                        Origin::Source,
+                        Positive::new(1337).unwrap()
+                    ),
+                ]
+            );
+
+            let typ2 = elements::group_of_single().canonical("test");
+            assert_eq!(
+                typ2,
+                vec![Signal::vec(
+                    "test_a".to_string(),
+                    Origin::Source,
+                    Positive::new(42).unwrap()
+                ),]
+            );
+        }
+
+        #[test]
+        fn logical_to_common_streams() {
+            let typ0 = streams::prim(8).canonical("test");
+            dbg!(&typ0);
+
+            let typ1 = streams::group().canonical("test");
+            dbg!(&typ1);
+        }
+
+        #[test]
+        fn interface_to_port() {
+            let if0 =
+                Interface::try_new("test", crate::design::Mode::In, streams::prim(8)).unwrap();
+            dbg!(if0.canonical("test"));
+            let if1 =
+                Interface::try_new("test", crate::design::Mode::Out, streams::group()).unwrap();
+            dbg!(if1.canonical("test"));
+        }
+    }
+
+    mod user {
+        use super::*;
+        use crate::generator::common::Field;
+
+        #[test]
+        fn logical_to_common_prim() {
+            let typ: Type = elements::prim(8).user("test").unwrap();
+            assert_eq!(typ, records::prim(8));
+        }
+
+        #[test]
+        fn logical_to_common_groups() {
+            let typ0: Type = elements::group().user("test").unwrap();
+            assert_eq!(typ0, records::rec("test"));
+
+            let typ1: Type = elements::group_nested().user("test").unwrap();
+            assert_eq!(typ1, records::rec_nested("test"));
+
+            let typ2: Type = elements::group_of_single().user("test").unwrap();
+            assert_eq!(typ2, records::rec_of_single("test"));
+        }
+
+        #[test]
+        fn logical_to_common_streams() {
+            let typ0: Type = streams::prim(8).user("test").unwrap();
+            assert_eq!(
+                typ0,
+                Type::Record(Record {
+                    identifier: "test_type".to_string(),
+                    fields: vec![
+                        Field::new("valid", Type::Bit, false),
+                        Field::new("ready", Type::Bit, true),
+                        Field::new("data", Type::bitvec(8), false)
+                    ]
+                })
+            );
+
+            let typ1: Type = streams::group().user("test").unwrap();
+            assert_eq!(
+                typ1,
+                Type::Record(Record {
+                    identifier: "test_type".to_string(),
+                    fields: vec![
+                        Field::new(
+                            "a",
+                            Type::Record(Record {
+                                identifier: "test_a_type".to_string(),
+                                fields: vec![
+                                    Field::new("valid", Type::Bit, false),
+                                    Field::new("ready", Type::Bit, true),
+                                    Field::new("data", Type::bitvec(42), false)
+                                ]
+                            }),
+                            false
+                        ),
+                        Field::new(
+                            "b",
+                            Type::Record(Record {
+                                identifier: "test_b_type".to_string(),
+                                fields: vec![
+                                    Field::new("valid", Type::Bit, false),
+                                    Field::new("ready", Type::Bit, true),
+                                    Field::new("data", Type::bitvec(1337), false)
+                                ]
+                            }),
+                            false
+                        )
+                    ]
+                })
+            );
+        }
+
+        #[test]
+        fn interface_to_port() {
+            let if0 =
+                Interface::try_new("test", crate::design::Mode::In, streams::prim(8)).unwrap();
+            dbg!(if0.user("test", "test"));
+            let if1 =
+                Interface::try_new("test", crate::design::Mode::Out, streams::group()).unwrap();
+            dbg!(if1.user("test", "test"));
+        }
+    }
 
     #[test]
     pub(crate) fn simple_streamlet() -> Result<()> {
         let streamlet = Streamlet::from_builder(
             Name::try_new("test")?,
             UniquelyNamedBuilder::new().with_items(vec![
-                Interface::try_new(
-                    "x",
-                    crate::design::Mode::In,
-                    crate::logical::tests::streams::single_element(),
-                )?,
-                Interface::try_new(
-                    "y",
-                    crate::design::Mode::Out,
-                    crate::logical::tests::streams::single_element(),
-                )?,
+                Interface::try_new("x", crate::design::Mode::In, streams::prim(8))?,
+                Interface::try_new("y", crate::design::Mode::Out, streams::group())?,
             ]),
         )?;
         // TODO(johanpel): write actual test
-        dbg!(&streamlet);
-        let common_streamlet: Component = streamlet.into();
-        dbg!(&common_streamlet);
-        println!("{}", common_streamlet.declare()?);
-        Ok(())
-    }
-
-    #[test]
-    fn interface_to_canonical() -> Result<()> {
-        let interface = Interface::try_new(
-            "x",
-            crate::design::Mode::Out,
-            crate::logical::tests::streams::single_element(),
-        )?;
-        let ports: Vec<Port> = interface.into();
-        // TODO(johanpel): write actual test
-        dbg!(ports);
-        Ok(())
-    }
-
-    #[test]
-    fn physical_low_complexity() -> Result<()> {
-        let phys = PhysicalStream::try_new(vec![("a", 4), ("b", 8)], 2, 0, 2, vec![])?;
-        let common_type = phys.synthesize("test");
-        // TODO(johanpel): write actual test
-        println!("{}", common_type.declare().unwrap());
-        Ok(())
-    }
-
-    #[test]
-    fn physical_high_complexity() -> Result<()> {
-        let phys = PhysicalStream::try_new(
-            vec![("a", 4), ("b", 8)],
-            4,
-            3,
-            8,
-            vec![("muh", 3), ("foo", 4)],
-        )?;
-
-        let common_type = phys.synthesize("test");
-
-        let mut comp = Component {
-            identifier: "MyComp".to_string(),
-            parameters: vec![],
-            ports: vec![Port::new("x", Mode::In, common_type)],
+        let common_streamlet = streamlet.user("test").unwrap();
+        let pkg = Library {
+            identifier: "boomer".to_string(),
+            components: vec![common_streamlet],
         };
-
-        comp.flatten_types();
-        // TODO(johanpel): write actual test
-        println!("{}", comp.declare().unwrap());
+        println!("{}", pkg.declare()?);
         Ok(())
     }
+
+    #[test]
+    pub(crate) fn nested_streams_streamlet() -> Result<()> {
+        let streamlet = Streamlet::from_builder(
+            Name::try_new("test")?,
+            UniquelyNamedBuilder::new().with_items(vec![
+                Interface::try_new("x", crate::design::Mode::In, streams::prim(8))?,
+                Interface::try_new("y", crate::design::Mode::Out, streams::nested())?,
+            ]),
+        )?;
+        // TODO(johanpel): write actual test
+        let common_streamlet = streamlet.user("test").unwrap();
+        let pkg = Library {
+            identifier: "testing".to_string(),
+            components: vec![common_streamlet],
+        };
+        println!("{}", pkg.declare()?);
+        Ok(())
+    }
+
+    //
+    // #[test]
+    // fn interface_to_canonical() -> Result<()> {
+    //     let interface = Interface::try_new(
+    //         "x",
+    //         crate::design::Mode::Out,
+    //         crate::logical::tests::streams::single_element(),
+    //     )?;
+    //     let ports: Vec<Port> = interface.into();
+    //     // TODO(johanpel): write actual test
+    //     dbg!(ports);
+    //     Ok(())
+    // }
+
+    // #[test]
+    // fn physical_low_complexity() -> Result<()> {
+    //     let phys = PhysicalStream::try_new(vec![("a", 4), ("b", 8)], 2, 0, 2, vec![])?;
+    //     let common_type = phys.synthesize("test");
+    //     // TODO(johanpel): write actual test
+    //     println!("{}", common_type.declare().unwrap());
+    //     Ok(())
+    // }
+
+    // #[test]
+    // fn physical_high_complexity() -> Result<()> {
+    //     let phys = PhysicalStream::try_new(
+    //         vec![("a", 4), ("b", 8)],
+    //         4,
+    //         3,
+    //         8,
+    //         vec![("muh", 3), ("foo", 4)],
+    //     )?;
+    //
+    //     let common_type = phys.synthesize("test");
+    //
+    //     let mut comp = Component {
+    //         identifier: "MyComp".to_string(),
+    //         parameters: vec![],
+    //         ports: vec![Port::new("x", Mode::In, common_type)],
+    //     };
+    //
+    //     comp.flatten_types();
+    //     // TODO(johanpel): write actual test
+    //     println!("{}", comp.declare().unwrap());
+    //     Ok(())
+    // }
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -41,7 +41,7 @@ macro_rules! cat {
 /// of a project.
 pub trait GenerateProject {
     /// Generate source files from a [common::Project] and save them to [path].
-    fn generate(&self, project: &Project, path: &Path) -> Result<()>;
+    fn generate(&self, project: &Project, path: impl AsRef<Path>) -> Result<()>;
 }
 
 /// Trait to create common representation types from things in the canonical
@@ -105,7 +105,7 @@ impl Typify for Group {
         let mut rec = Record::new_empty(cat!(n.clone(), "type"));
         for (field_name, field_logical) in self.iter() {
             if let Some(field_common_type) = field_logical.user(cat!(n.clone(), field_name)) {
-                rec.insert_field(field_name, field_common_type, false)
+                rec.insert_field(field_name.to_string(), field_common_type, false)
             }
         }
         Some(Type::Record(rec))
@@ -268,15 +268,15 @@ impl Componentify for Streamlet {
             identifier: self.identifier().to_string(),
             parameters: vec![],
             ports: self
-            .interfaces()
-            .into_iter()
-            .flat_map(|interface| {
-                interface.user(
-                interface.identifier(),
-                cat!(self.identifier().to_string(), interface.identifier()),
-                        )
-                    })
-                    .collect(),
+                .interfaces()
+                .into_iter()
+                .flat_map(|interface| {
+                    interface.user(
+                        interface.identifier(),
+                        cat!(self.identifier().to_string(), interface.identifier()),
+                    )
+                })
+                .collect(),
         })
     }
 

--- a/src/generator/vhdl/mod.rs
+++ b/src/generator/vhdl/mod.rs
@@ -63,12 +63,12 @@ pub struct VHDLConfig {
     ///              package.
     ///   fancy: generates the canonical components that wrap a more user-friendly version for the
     ///          user to implement.
-    #[structopt(short, long)]
+    #[cfg_attr(feature = "cli", structopt(short, long))]
     abstraction: Option<AbstractionLevel>,
 
     /// Suffix of generated files. Default = "gen", such that
     /// generated files are named <name>.gen.vhd.
-    #[structopt(short, long)]
+    #[cfg_attr(feature = "cli", structopt(short, long))]
     suffix: Option<String>,
 }
 
@@ -95,9 +95,9 @@ impl From<VHDLConfig> for VHDLBackEnd {
 }
 
 impl GenerateProject for VHDLBackEnd {
-    fn generate(&self, project: &Project, path: &Path) -> Result<()> {
+    fn generate(&self, project: &Project, path: impl AsRef<Path>) -> Result<()> {
         // Create the project directory.
-        let mut dir = path.to_path_buf();
+        let mut dir = path.as_ref().to_path_buf();
         dir.push(project.identifier.clone());
         std::fs::create_dir_all(dir.as_path())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,23 +191,11 @@ impl From<Name> for String {
     }
 }
 
-impl From<&Name> for String {
-    fn from(name: &Name) -> Self {
-        name.0.to_string()
-    }
-}
-
-impl AsRef<str> for Name {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
 use std::ops::Deref;
 impl Deref for Name {
     type Target = str;
     fn deref(&self) -> &str {
-        self.as_ref()
+        self.0.as_ref()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,12 @@ impl From<Name> for String {
     }
 }
 
+impl From<&Name> for String {
+    fn from(name: &Name) -> Self {
+        name.0.to_string()
+    }
+}
+
 impl AsRef<str> for Name {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
@@ -247,22 +253,20 @@ impl fmt::Display for Name {
     }
 }
 
-use std::collections::VecDeque;
-
 /// Type-safe path for names.
 ///
 /// Allows wrapping a set of valid names in a hierarchy.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PathName(VecDeque<Name>);
+pub struct PathName(Vec<Name>);
 
 use std::convert::TryInto;
 impl PathName {
     pub(crate) fn new_empty() -> Self {
-        PathName(VecDeque::new())
+        PathName(Vec::new())
     }
 
-    pub fn new(names: impl IntoIterator<Item = Name>) -> Self {
-        PathName(names.into_iter().collect())
+    pub fn new(names: impl Iterator<Item = Name>) -> Self {
+        PathName(names.collect())
     }
 
     pub fn try_new(
@@ -280,8 +284,32 @@ impl PathName {
         self.0.is_empty()
     }
 
-    pub(crate) fn push_back(&mut self, name: impl Into<Name>) {
-        self.0.push_back(name.into());
+    pub fn push(&mut self, name: impl Into<Name>) {
+        self.0.push(name.into())
+    }
+
+    pub(crate) fn with_parent(&self, name: impl Into<Name>) -> PathName {
+        let mut result: Vec<Name> = Vec::with_capacity(self.len() + 1);
+        result.push(name.into());
+        let mut names = self.0.clone().into_iter();
+        result.extend(&mut names);
+        PathName::new(result.into_iter())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn last(&self) -> Option<&Name> {
+        self.0.last()
+    }
+
+    pub fn parent(&self) -> Option<PathName> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(PathName(self.0[..self.len() - 1].to_vec()))
+        }
     }
 }
 
@@ -304,7 +332,7 @@ impl fmt::Display for PathName {
 
 impl<'a> IntoIterator for &'a PathName {
     type Item = &'a Name;
-    type IntoIter = std::collections::vec_deque::Iter<'a, Name>;
+    type IntoIter = std::slice::Iter<'a, Name>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -312,17 +340,16 @@ impl<'a> IntoIterator for &'a PathName {
 }
 
 use std::iter::FromIterator;
+
 impl FromIterator<Name> for PathName {
     fn from_iter<I: IntoIterator<Item = Name>>(iter: I) -> Self {
-        PathName(VecDeque::from_iter(iter))
+        PathName(iter.into_iter().collect())
     }
 }
 
 impl From<Name> for PathName {
     fn from(name: Name) -> Self {
-        let mut vec = VecDeque::with_capacity(1);
-        vec.push_back(name);
-        PathName(vec)
+        PathName(vec![name])
     }
 }
 

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -310,6 +310,10 @@ impl Group {
         }
         Ok(Group(map))
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalStreamType)> {
+        self.0.iter()
+}
 }
 
 impl From<Group> for LogicalStreamType {
@@ -629,7 +633,7 @@ impl LogicalStreamType {
                         .map(|(name, stream)| {
                             stream.split().streams.into_iter().map(
                                 move |(mut path_name, stream_)| {
-                                    path_name.push_back(name.clone());
+                                    path_name.push(name.clone());
                                     (path_name, stream_)
                                 },
                             )
@@ -658,9 +662,9 @@ impl LogicalStreamType {
             LogicalStreamType::Group(Group(inner)) => {
                 inner.iter().for_each(|(name, stream)| {
                     stream.fields().iter().for_each(|(path_name, bit_count)| {
-                        let mut path_name = path_name.clone();
-                        path_name.push_back(name.clone());
-                        fields.insert(path_name, *bit_count).unwrap();
+                        fields
+                            .insert(path_name.with_parent(name.clone()), *bit_count)
+                            .unwrap();
                     })
                 });
                 fields

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -53,5 +53,5 @@ where
 
 /// Trait for things that have names.
 pub trait Identify {
-    fn name(&self) -> &str;
+    fn identifier(&self) -> &str;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,7 +50,7 @@ impl<T: Identify> UniquelyNamedBuilder<T> {
     }
 
     pub fn finish(self) -> Result<Vec<T>> {
-        let set: HashSet<&str> = self.items.iter().map(|item| item.name()).collect();
+        let set: HashSet<&str> = self.items.iter().map(|item| item.identifier()).collect();
         if self.items.len() != set.len() {
             Err(Error::UnexpectedDuplicate)
         } else {


### PR DESCRIPTION
An initial implementation of conversion functions from Tydi abstractions to common representation.
Needs more debugging that can be done alongside "finalizing" the vhdl back-end, so it can be merged to phase 1 and continued from there.