### PR TITLE
Add integration tests from SDF to VHDL back-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
+![Tydi logo](https://raw.github.com/abs-tudelft/tydi/master/book/src/tydi_logo.svg?sanitize=true)
+
 # Tydi
 
-An open specification for complex data structures over hardware streams.
+An open [specification] for complex data structures over hardware streams.
 
 ## License
 
 The `tydi` crate is licensed under the [Apache-2.0] license. See [LICENSE].
 
+[Specification]: https://abs-tudelft.github.io/tydi
 [Apache-2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [LICENSE]: ./LICENSE

--- a/src/design/streamlet.rs
+++ b/src/design/streamlet.rs
@@ -3,6 +3,7 @@
 //! A streamlet is a component where every [Interface] has a [LogicalStreamType].
 
 use crate::logical::LogicalStreamType;
+use crate::traits::Identify;
 use crate::util::UniquelyNamedBuilder;
 use crate::{Error, Name, Result};
 use std::convert::TryInto;
@@ -28,7 +29,7 @@ impl Streamlet {
     }
 }
 
-impl crate::traits::Identify for Streamlet {
+impl Identify for Streamlet {
     fn identifier(&self) -> &str {
         self.name.as_ref()
     }

--- a/src/generator/common.rs
+++ b/src/generator/common.rs
@@ -148,7 +148,7 @@ impl Record {
 
     /// Returns true if the record contains a field that is reversed.
     pub fn has_reversed(&self) -> bool {
-        self.fields.iter().fold(false, |b, i| b || i.reversed)
+        self.fields.iter().any(|i| i.reversed)
     }
 
     /// Returns an iterable over the fields.

--- a/src/generator/common.rs
+++ b/src/generator/common.rs
@@ -28,29 +28,43 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-use crate::NonNegative;
+use crate::cat;
+use crate::traits::Identify;
+use crate::{NonNegative, Reversed};
 
 /// Inner struct for `Type::Array`
 #[derive(Debug, Clone, PartialEq)]
 pub struct Array {
     /// VHDL identifier for this array type.
-    pub identifier: String,
+    identifier: String,
     /// The size of the array.
     pub size: usize,
     /// The type of the array elements.
     pub typ: Box<Type>,
 }
 
+impl Identify for Array {
+    fn identifier(&self) -> &str {
+        self.identifier.as_str()
+    }
+}
+
 /// A field for a `Record`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Field {
     /// Name of the field.
-    pub name: String,
+    name: String,
     /// Type of the field.
-    pub typ: Type,
+    typ: Type,
     /// Whether the direction of this field should be reversed
     /// w.r.t. the other fields in the record for bulk connections.
-    pub reversed: bool,
+    reversed: bool,
+}
+
+impl Identify for Field {
+    fn identifier(&self) -> &str {
+        self.name.as_str()
+    }
 }
 
 impl Field {
@@ -62,20 +76,41 @@ impl Field {
             reversed,
         }
     }
+
+    pub fn typ(&self) -> &Type {
+        &self.typ
+    }
+
+    pub fn is_reversed(&self) -> bool {
+        self.reversed
+    }
+}
+
+impl Reversed for Field {
+    fn reversed(&self) -> Self {
+        Field::new(self.name.clone(), self.typ.clone(), !self.reversed)
+    }
 }
 
 /// Inner struct for `Type::Record`
 #[derive(Debug, Clone, PartialEq)]
 pub struct Record {
     /// VHDL identifier for this record type.
-    pub identifier: String,
+    identifier: String,
     /// The fields of the record.
-    pub fields: Vec<Field>,
+    fields: Vec<Field>,
+}
+
+impl Identify for Record {
+    fn identifier(&self) -> &str {
+        self.identifier.as_str()
+    }
 }
 
 impl Record {
     /// Construct a new record.
     pub fn new(name: impl Into<String>, fields: Vec<Field>) -> Record {
+        // TODO(johanpel): records should be constructed through a UniquelyNamedBuilder
         Record {
             identifier: name.into(),
             fields,
@@ -101,9 +136,46 @@ impl Record {
         }
     }
 
-    /// Add a field to the record.
-    pub fn insert_field(&mut self, name: impl Into<String>, typ: Type, reversed: bool) {
+    /// Create a new field and add it to the record.
+    pub fn insert_new_field(&mut self, name: impl Into<String>, typ: Type, reversed: bool) {
         self.fields.push(Field::new(name, typ, reversed));
+    }
+
+    /// Add a field to the record.
+    pub fn insert(&mut self, field: Field) {
+        self.fields.push(field);
+    }
+
+    /// Returns true if the record contains a field that is reversed.
+    pub fn has_reversed(&self) -> bool {
+        self.fields.iter().fold(false, |b, i| b || i.reversed)
+    }
+
+    /// Returns an iterable over the fields.
+    pub fn fields(&self) -> impl Iterator<Item = &Field> {
+        self.fields.iter()
+    }
+
+    /// Returns true if record contains no fields.
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Append a string to the name of this record, and any nested records.
+    pub fn append_name_nested(&self, with: impl Into<String>) -> Self {
+        let p: String = with.into();
+        let mut result = Record::new_empty(cat!(self.identifier, p.clone()));
+        for f in self.fields() {
+            result.insert(match f.typ() {
+                Type::Record(r) => Field::new(
+                    f.identifier(),
+                    Type::Record(r.append_name_nested(p.clone())),
+                    f.reversed,
+                ),
+                _ => f.clone(),
+            });
+        }
+        result
     }
 }
 
@@ -150,6 +222,14 @@ impl Type {
         }
         result
     }
+
+    // Returns true if the type contains a reversed field.
+    pub fn has_reversed(&self) -> bool {
+        match self {
+            Type::Record(rec) => rec.has_reversed(),
+            _ => false,
+        }
+    }
 }
 
 /// A parameter for components.
@@ -166,21 +246,26 @@ pub enum Mode {
     In,
     /// Output.
     Out,
-    /// Bidirectional.
-    Inout,
-    /// None.
-    None,
+}
+
+impl Reversed for Mode {
+    fn reversed(&self) -> Self {
+        match self {
+            Mode::In => Mode::Out,
+            Mode::Out => Mode::In,
+        }
+    }
 }
 
 /// A port.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Port {
     /// Port identifier.
-    pub identifier: String,
+    identifier: String,
     /// Port mode.
-    pub mode: Mode,
+    mode: Mode,
     /// Port type.
-    pub typ: Type,
+    typ: Type,
 }
 
 impl Port {
@@ -191,20 +276,60 @@ impl Port {
             typ,
         }
     }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    pub fn typ(&self) -> Type {
+        self.typ.clone()
+    }
+}
+
+impl Identify for Port {
+    fn identifier(&self) -> &str {
+        self.identifier.as_str()
+    }
 }
 
 /// A component.
 #[derive(Debug, Clone)]
 pub struct Component {
     /// Component identifier.
-    pub identifier: String,
+    identifier: String,
     /// The parameters of the component..
-    pub parameters: Vec<Parameter>,
+    parameters: Vec<Parameter>,
     /// The ports of the component.
-    pub ports: Vec<Port>,
+    ports: Vec<Port>,
+}
+
+impl Identify for Component {
+    fn identifier(&self) -> &str {
+        self.identifier.as_str()
+    }
 }
 
 impl Component {
+    pub fn new(
+        identifier: impl Into<String>,
+        parameters: Vec<Parameter>,
+        ports: Vec<Port>,
+    ) -> Component {
+        Component {
+            identifier: identifier.into(),
+            parameters,
+            ports,
+        }
+    }
+
+    pub fn ports(&self) -> &Vec<Port> {
+        &self.ports
+    }
+
+    pub fn parameters(&self) -> &Vec<Parameter> {
+        &self.parameters
+    }
+
     pub fn flatten_types(&mut self) {
         let mut new_ports: Vec<Port> = Vec::new();
         self.ports.iter().for_each(|port| {
@@ -357,5 +482,18 @@ pub(crate) mod test {
         assert_eq!(flat[2].0[1], "b".to_string());
         assert_eq!(flat[2].1, Type::bitvec(4));
         assert_eq!(flat[2].2, true);
+    }
+
+    #[test]
+    fn rec_has_reversed() {
+        assert!(test_rec().has_reversed());
+        assert!(!Type::record(
+            "test",
+            vec![
+                Field::new("a", Type::Bit, false),
+                Field::new("b", Type::Bit, false),
+            ],
+        )
+        .has_reversed());
     }
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -75,7 +75,7 @@ pub trait Portify {
 /// Trait to create common representation components from things in the canonical
 /// way and user-friendly way.
 pub trait Componentify {
-    fn user(&self, suffix: Option<&str>) -> Option<Component> {
+    fn user(&self, _suffix: Option<&str>) -> Option<Component> {
         None
     }
     fn canonical(&self, suffix: Option<&str>) -> Component;

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::design::{Interface, Streamlet};
 use crate::generator::common::{Component, Library, Mode, Port, Project, Record, Type};
-use crate::logical::{Group, LogicalStreamType, Stream};
+use crate::logical::{Group, LogicalStreamType, Stream, Union};
 use crate::physical::{Origin, Signal, Width};
 use crate::traits::Identify;
 use crate::Result;
@@ -15,9 +15,15 @@ pub mod chisel;
 pub mod common;
 pub mod vhdl;
 
+// Generator-global constants:
+
+/// Suffix provided to the canonical representation of streamlet components.
+// TODO(johanpel): come up with a better suffix to make users understand to
+//                 preferably not touch the canonical component.
+pub const CANON_SUFFIX: Option<&str> = Some("com");
+
 /// Concatenate stuff using format with an underscore in between.
 /// Useful if the separator ever changes.
-
 #[macro_export]
 macro_rules! cat {
     ($a:expr) => {{
@@ -69,10 +75,10 @@ pub trait Portify {
 /// Trait to create common representation components from things in the canonical
 /// way and user-friendly way.
 pub trait Componentify {
-    fn user(&self) -> Option<Component> {
+    fn user(&self, suffix: Option<&str>) -> Option<Component> {
         None
     }
-    fn canonical(&self) -> Component;
+    fn canonical(&self, suffix: Option<&str>) -> Component;
 }
 
 impl Typify for LogicalStreamType {
@@ -80,21 +86,23 @@ impl Typify for LogicalStreamType {
     /// flattened through synthesize.
     fn user(&self, prefix: impl Into<String>) -> Option<Type> {
         match self {
+            LogicalStreamType::Null => None,
             LogicalStreamType::Bits(width) => Some(Type::bitvec(width.get())),
             LogicalStreamType::Group(group) => group.user(prefix),
             LogicalStreamType::Stream(stream) => stream.user(prefix),
-            _ => todo!(),
+            LogicalStreamType::Union(union) => union.user(prefix),
         }
     }
 
     fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal> {
         match self {
+            LogicalStreamType::Null => Vec::new(),
             LogicalStreamType::Bits(width) => {
                 vec![Signal::vec(prefix.into(), Origin::Source, *width)]
             }
             LogicalStreamType::Group(group) => group.canonical(prefix),
             LogicalStreamType::Stream(stream) => stream.canonical(prefix),
-            _ => todo!(),
+            LogicalStreamType::Union(union) => union.canonical(prefix),
         }
     }
 }
@@ -122,7 +130,42 @@ impl Typify for Group {
     }
 }
 
+impl Typify for Union {
+    fn user(&self, prefix: impl Into<String>) -> Option<Type> {
+        let n: String = prefix.into();
+        let mut rec = Record::new_empty(cat!(n.clone(), "type"));
+        if let Some((tag_name, tag_bc)) = self.tag() {
+            rec.insert_new_field(tag_name, Type::bitvec(tag_bc.get()), false);
+        }
+        for (field_name, field_logical) in self.iter() {
+            if let Some(field_common_type) = field_logical.user(cat!(n.clone(), field_name)) {
+                rec.insert_new_field(field_name, field_common_type, false);
+            }
+        }
+        Some(Type::Record(rec))
+    }
+
+    fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal> {
+        let n: String = prefix.into();
+        let mut result = Vec::new();
+        if let Some((tag_name, tag_bc)) = self.tag() {
+            result.push(Signal::vec(
+                cat!(n.clone(), tag_name),
+                Origin::Source,
+                tag_bc,
+            ));
+        }
+        for (field_name, field_logical) in self.iter() {
+            let field_result = field_logical.canonical(cat!(n.clone(), field_name));
+            result.extend(field_result);
+        }
+        result
+    }
+}
+
 impl Typify for Stream {
+    /// This implementation for Stream assumes the parent LogicalStreamType has already been
+    /// flattened through synthesize.
     fn user(&self, prefix: impl Into<String>) -> Option<Type> {
         // We need to wrap the Stream back into a LogicalStreamType
         // to be able to use various methods for checks and synthesize.
@@ -172,6 +215,8 @@ impl Typify for Stream {
         }
     }
 
+    /// This implementation for Stream assumes the parent LogicalStreamType has already been
+    /// flattened through synthesize.
     fn canonical(&self, prefix: impl Into<String>) -> Vec<Signal> {
         let n: String = prefix.into();
         let mut result = Vec::new();
@@ -203,10 +248,12 @@ impl From<Width> for Type {
 /// Trait that helps to determine the common representation port mode given a streamlet interface
 /// mode.
 pub trait ModeFor {
+    /// Return the port mode of self, given a streamlet interface mode.
     fn mode_for(&self, streamlet_mode: crate::design::Mode) -> Mode;
 }
 
 impl ModeFor for Origin {
+    /// Return the common representation port mode for this signal origin, given the interface mode.
     fn mode_for(&self, streamlet_mode: crate::design::Mode) -> Mode {
         match self {
             Origin::Sink => match streamlet_mode {
@@ -228,7 +275,11 @@ impl Portify for Interface {
 
         let mut result = Vec::new();
 
-        // TODO(johanpel): asynchronous logicalstreamtypes
+        let split = self.typ().split();
+
+        if let Some(sig_type) = split.signal().user(tn.clone()) {
+            result.push(Port::new(cat!(n.clone()), self.mode().into(), sig_type));
+        }
 
         // Split the LogicalStreamType up into discrete, simple streams.
         for (path, simple_stream) in self.typ().split().streams() {
@@ -265,31 +316,34 @@ impl From<crate::design::Mode> for Mode {
 }
 
 impl Componentify for Streamlet {
-    fn user(&self) -> Option<Component> {
+    fn user(&self, suffix: Option<&str>) -> Option<Component> {
         Some(Component::new(
-            self.identifier(),
+            cat!(self.identifier().to_string(), suffix.unwrap_or("")),
             vec![],
             self.interfaces()
                 .into_iter()
                 .flat_map(|interface| {
-                    let interface_ports = interface.user(
+                    interface.user(
                         interface.identifier(),
                         cat!(self.identifier().to_string(), interface.identifier()),
-                    );
-                    interface_ports
+                    )
                 })
                 .collect(),
         ))
     }
 
-    fn canonical(&self) -> Component {
-        Component::new(self.identifier().to_string(), vec![], {
-            let mut all_ports = Vec::new();
-            self.interfaces().into_iter().for_each(|interface| {
-                all_ports.extend(interface.canonical(interface.identifier()));
-            });
-            all_ports
-        })
+    fn canonical(&self, suffix: Option<&str>) -> Component {
+        Component::new(
+            cat!(self.identifier().to_string(), suffix.unwrap_or("")),
+            vec![],
+            {
+                let mut all_ports = Vec::new();
+                self.interfaces().into_iter().for_each(|interface| {
+                    all_ports.extend(interface.canonical(interface.identifier()));
+                });
+                all_ports
+            },
+        )
     }
 }
 
@@ -300,8 +354,13 @@ impl From<crate::design::Library> for Library {
             components: l
                 .streamlets()
                 .into_iter()
-                .map(|s| s.user())
-                .filter_map(|s| s)
+                .flat_map(|s| {
+                    let mut result = vec![s.canonical(CANON_SUFFIX)];
+                    if let Some(user) = s.user(None) {
+                        result.push(user);
+                    }
+                    result
+                })
                 .collect(),
         }
     }
@@ -508,6 +567,7 @@ pub(crate) mod tests {
             let if1 =
                 Interface::try_new("test", crate::design::Mode::Out, streams::group()).unwrap();
             dbg!(if1.user("test", "test"));
+            // TODO(johanpel): write actual test
         }
     }
 
@@ -521,7 +581,7 @@ pub(crate) mod tests {
             ]),
         )?;
         // TODO(johanpel): write actual test
-        let common_streamlet = streamlet.user().unwrap();
+        let common_streamlet = streamlet.user(None).unwrap();
         let pkg = Library {
             identifier: "boomer".to_string(),
             components: vec![common_streamlet],
@@ -540,7 +600,7 @@ pub(crate) mod tests {
             ]),
         )?;
         // TODO(johanpel): write actual test
-        let common_streamlet = streamlet.user().unwrap();
+        let common_streamlet = streamlet.user(None).unwrap();
         let pkg = Library {
             identifier: "testing".to_string(),
             components: vec![common_streamlet],

--- a/src/generator/vhdl/impls.rs
+++ b/src/generator/vhdl/impls.rs
@@ -59,8 +59,8 @@ impl VHDLIdentifier for Type {
         // Records and arrays use type definitions.
         // Any other types are used directly.
         match self {
-            Type::Record(rec) => Ok(rec.identifier().clone().to_string()),
-            Type::Array(arr) => Ok(arr.identifier().clone().to_string()),
+            Type::Record(rec) => Ok(rec.identifier().to_string()),
+            Type::Array(arr) => Ok(arr.identifier().to_string()),
             _ => self.declare(),
         }
     }

--- a/src/generator/vhdl/impls.rs
+++ b/src/generator/vhdl/impls.rs
@@ -4,16 +4,15 @@ use std::collections::HashMap;
 
 use crate::error::Error::BackEndError;
 use crate::generator::common::{Component, Library, Mode, Port, Type};
-use crate::generator::vhdl::{Analyze, Declare, Identify};
+use crate::generator::vhdl::{Analyze, Declare, VHDLIdentifier};
+use crate::traits::Identify;
 use crate::Result;
 
-impl Identify for Mode {
-    fn identify(&self) -> Result<String> {
+impl VHDLIdentifier for Mode {
+    fn vhdl_identifier(&self) -> Result<String> {
         match self {
             Mode::In => Ok("in".to_string()),
             Mode::Out => Ok("out".to_string()),
-            Mode::Inout => Ok("inout".to_string()),
-            _ => Err(BackEndError("Mode not synthesizable.".to_string())),
         }
     }
 }
@@ -31,10 +30,15 @@ impl Declare for Type {
                 ))
             }
             Type::Record(rec) => {
-                let mut result = format!("record {}\n", rec.identifier);
-                for field in &rec.fields {
+                let mut result = format!("record {}\n", rec.identifier());
+                for field in rec.fields() {
                     result.push_str(
-                        format!("  {} : {};\n", field.name, field.typ.identify()?).as_str(),
+                        format!(
+                            "  {} : {};\n",
+                            field.identifier(),
+                            field.typ().vhdl_identifier()?
+                        )
+                        .as_str(),
                     );
                 }
                 result.push_str("end record;");
@@ -50,13 +54,13 @@ impl Declare for Type {
     }
 }
 
-impl Identify for Type {
-    fn identify(&self) -> Result<String> {
+impl VHDLIdentifier for Type {
+    fn vhdl_identifier(&self) -> Result<String> {
         // Records and arrays use type definitions.
         // Any other types are used directly.
         match self {
-            Type::Record(rec) => Ok(rec.identifier.clone()),
-            Type::Array(arr) => Ok(arr.identifier.clone()),
+            Type::Record(rec) => Ok(rec.identifier().clone().to_string()),
+            Type::Array(arr) => Ok(arr.identifier().clone().to_string()),
             _ => self.declare(),
         }
     }
@@ -69,8 +73,8 @@ impl Analyze for Type {
             Type::Record(rec) => {
                 let mut result: Vec<Type> = vec![];
                 result.push(self.clone());
-                for f in rec.fields.iter() {
-                    let children = f.typ.list_record_types();
+                for f in rec.fields().into_iter() {
+                    let children = f.typ().list_record_types();
                     result.extend(children.into_iter());
                 }
                 result
@@ -84,35 +88,35 @@ impl Declare for Port {
     fn declare(&self) -> Result<String> {
         Ok(format!(
             "{} : {} {}",
-            self.identifier,
-            self.mode.identify()?,
-            self.typ.identify()?
+            self.identifier(),
+            self.mode().vhdl_identifier()?,
+            self.typ().vhdl_identifier()?
         ))
     }
 }
 
-impl Identify for Port {
-    fn identify(&self) -> Result<String> {
-        Ok(self.identifier.to_string())
+impl VHDLIdentifier for Port {
+    fn vhdl_identifier(&self) -> Result<String> {
+        Ok(self.identifier().to_string())
     }
 }
 
 impl Analyze for Port {
     fn list_record_types(&self) -> Vec<Type> {
-        self.typ.list_record_types()
+        self.typ().list_record_types()
     }
 }
 
 impl Declare for Component {
     fn declare(&self) -> Result<String> {
         let mut result = String::new();
-        result.push_str(format!("component {}\n", self.identifier).as_str());
-        if !self.ports.is_empty() {
-            let mut ports = self.ports.iter().peekable();
+        result.push_str(format!("component {}\n", self.identifier()).as_str());
+        if !self.ports().is_empty() {
+            let mut ports = self.ports().iter().peekable();
             result.push_str("  port(\n");
             while let Some(p) = ports.next() {
                 result.push_str("    ");
-                result.push_str(p.declare()?.to_string().as_str());
+                result.push_str(p.declare()?.as_str());
                 if ports.peek().is_some() {
                     result.push_str(";\n");
                 } else {
@@ -129,7 +133,7 @@ impl Declare for Component {
 impl Analyze for Component {
     fn list_record_types(&self) -> Vec<Type> {
         let mut result: Vec<Type> = vec![];
-        for p in &self.ports {
+        for p in self.ports().iter() {
             let children = p.list_record_types();
             result.extend(children.into_iter());
         }
@@ -149,9 +153,9 @@ impl Declare for Library {
         for c in &self.components {
             let comp_records = c.list_record_types();
             for r in comp_records.iter() {
-                match type_ids.get(&r.identify()?) {
+                match type_ids.get(&r.vhdl_identifier()?) {
                     None => {
-                        type_ids.insert(r.identify()?, r.clone());
+                        type_ids.insert(r.vhdl_identifier()?, r.clone());
                         result.push_str(format!("{}\n\n", r.declare()?).as_str());
                     }
                     Some(already_defined_type) => {
@@ -159,7 +163,7 @@ impl Declare for Library {
                             return Err(BackEndError(format!(
                                 "Type name conflict: {}",
                                 already_defined_type
-                                    .identify()
+                                    .vhdl_identifier()
                                     .unwrap_or_else(|_| "".to_string())
                             )));
                         }
@@ -182,8 +186,8 @@ mod test {
     fn test_mode_decl() {
         let m0 = Mode::In;
         let m1 = Mode::Out;
-        assert_eq!(m0.identify().unwrap(), "in");
-        assert_eq!(m1.identify().unwrap(), "out");
+        assert_eq!(m0.vhdl_identifier().unwrap(), "in");
+        assert_eq!(m1.vhdl_identifier().unwrap(), "out");
     }
 
     #[test]

--- a/src/generator/vhdl/mod.rs
+++ b/src/generator/vhdl/mod.rs
@@ -131,10 +131,7 @@ impl Split for Type {
         match self {
             Type::Record(rec) => {
                 let (down_rec, up_rec) = rec.split();
-                (
-                    down_rec.and_then(|r| Some(Type::Record(r))),
-                    up_rec.and_then(|r| Some(Type::Record(r))),
-                )
+                (down_rec.map(Type::Record), up_rec.map(Type::Record))
             }
             _ => (Some(self.clone()), None),
         }
@@ -147,8 +144,8 @@ impl Split for Field {
         let (down_type, up_type) = self.typ().split();
 
         let result = (
-            down_type.and_then(|t| Some(Field::new(self.identifier(), t, false))),
-            up_type.and_then(|t| Some(Field::new(self.identifier(), t, false))),
+            down_type.map(|t| Field::new(self.identifier(), t, false)),
+            up_type.map(|t| Field::new(self.identifier(), t, false)),
         );
 
         if self.is_reversed() {
@@ -167,11 +164,11 @@ impl Split for Record {
 
         for f in self.fields().into_iter() {
             let (down_field, up_field) = f.split();
-            if down_field.is_some() {
-                down_rec.insert(down_field.unwrap())
+            if let Some(df) = down_field {
+                down_rec.insert(df)
             };
-            if up_field.is_some() {
-                up_rec.insert(up_field.unwrap())
+            if let Some(uf) = up_field {
+                up_rec.insert(uf)
             };
         }
 

--- a/src/generator/vhdl/mod.rs
+++ b/src/generator/vhdl/mod.rs
@@ -5,10 +5,12 @@
 
 use crate::generator::common::*;
 use crate::generator::GenerateProject;
-use crate::{Error, Result};
+use crate::{Error, Result, Reversed};
 use log::debug;
 use std::path::Path;
 
+use crate::cat;
+use crate::traits::Identify;
 use std::str::FromStr;
 #[cfg(feature = "cli")]
 use structopt::StructOpt;
@@ -22,9 +24,9 @@ pub trait Declare {
 }
 
 /// Generate trait for VHDL identifiers.
-pub trait Identify {
+pub trait VHDLIdentifier {
     /// Generate a VHDL identifier from self.
-    fn identify(&self) -> Result<String>;
+    fn vhdl_identifier(&self) -> Result<String>;
 }
 
 /// Analyze trait for VHDL objects.
@@ -115,21 +117,271 @@ impl GenerateProject for VHDLBackEnd {
     }
 }
 
+// Trait to split types and record fields into a VHDL-friendly version.
+trait Split {
+    // Split up self into a (downstream, upstream) version, if applicable.
+    fn split(&self) -> (Option<Self>, Option<Self>)
+    where
+        Self: Sized;
+}
+
+impl Split for Type {
+    fn split(&self) -> (Option<Self>, Option<Self>) {
+        match self {
+            Type::Record(rec) => {
+                let (down_rec, up_rec) = rec.split();
+                (
+                    down_rec.and_then(|r| Some(Type::Record(r))),
+                    up_rec.and_then(|r| Some(Type::Record(r))),
+                )
+            }
+            _ => (Some(self.clone()), None),
+        }
+    }
+}
+
+impl Split for Field {
+    fn split(&self) -> (Option<Self>, Option<Self>) {
+        // Split the inner type.
+        let (down_type, up_type) = self.typ().split();
+
+        let result = (
+            down_type.and_then(|t| Some(Field::new(self.identifier(), t, false))),
+            up_type.and_then(|t| Some(Field::new(self.identifier(), t, false))),
+        );
+
+        if self.is_reversed() {
+            // If this field itself is reversed, swap the result of splitting the field type.
+            (result.1, result.0)
+        } else {
+            result
+        }
+    }
+}
+
+impl Split for Record {
+    fn split(&self) -> (Option<Self>, Option<Self>) {
+        let mut down_rec = Record::new_empty(self.identifier());
+        let mut up_rec = Record::new_empty(self.identifier());
+
+        for f in self.fields().into_iter() {
+            let (down_field, up_field) = f.split();
+            if down_field.is_some() {
+                down_rec.insert(down_field.unwrap())
+            };
+            if up_field.is_some() {
+                up_rec.insert(up_field.unwrap())
+            };
+        }
+
+        let f = |r: Record| if r.is_empty() { None } else { Some(r) };
+
+        (f(down_rec), f(up_rec))
+    }
+}
+
+impl Split for Port {
+    fn split(&self) -> (Option<Self>, Option<Self>) {
+        let (type_down, type_up) = self.typ().split();
+        (
+            type_down.and_then(|t| {
+                Some(Port::new(
+                    cat!(self.identifier(), "dn"),
+                    self.mode(),
+                    match t {
+                        Type::Record(r) => Type::Record(r.append_name_nested("dn")),
+                        _ => t,
+                    },
+                ))
+            }),
+            type_up.and_then(|t| {
+                Some(Port::new(
+                    cat!(self.identifier(), "up"),
+                    self.mode().reversed(),
+                    match t {
+                        Type::Record(r) => Type::Record(r.append_name_nested("up")),
+                        _ => t,
+                    },
+                ))
+            }),
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::generator::common::test::*;
+    use crate::generator::Componentify;
+    use crate::Reversed;
     use std::fs;
 
     #[test]
-    fn test_type_conflict() {
+    fn split_primitive() {
+        assert_eq!(Type::bitvec(3).split(), (Some(Type::bitvec(3)), None));
+    }
+
+    #[test]
+    fn split_field() {
+        let f0 = Field::new("test", Type::bitvec(3), false);
+        assert_eq!(f0.split(), (Some(f0), None));
+
+        let f1 = Field::new("test", Type::bitvec(3), true);
+        assert_eq!(f1.split(), (None, Some(f1.reversed())));
+    }
+
+    #[test]
+    fn split_simple_rec() {
+        let rec = Type::record(
+            "ra",
+            vec![
+                Field::new("fc", Type::Bit, false),
+                Field::new("fd", Type::Bit, true),
+            ],
+        );
+
+        assert_eq!(
+            rec.split().0.unwrap(),
+            Type::record("ra", vec![Field::new("fc", Type::Bit, false)])
+        );
+
+        assert_eq!(
+            rec.split().1.unwrap(),
+            Type::record("ra", vec![Field::new("fd", Type::Bit, false)])
+        );
+    }
+
+    #[test]
+    fn split_nested_rec() {
+        let rec = Type::record(
+            "test",
+            vec![
+                Field::new(
+                    "fa",
+                    Type::record(
+                        "ra",
+                        vec![
+                            Field::new("fc", Type::Bit, false),
+                            Field::new("fd", Type::Bit, true),
+                        ],
+                    ),
+                    false,
+                ),
+                Field::new(
+                    "fb",
+                    Type::record(
+                        "rb",
+                        vec![
+                            Field::new("fe", Type::Bit, false),
+                            Field::new("ff", Type::Bit, true),
+                        ],
+                    ),
+                    true,
+                ),
+            ],
+        );
+
+        assert_eq!(
+            rec.split().0.unwrap(),
+            Type::record(
+                "test",
+                vec![
+                    Field::new(
+                        "fa",
+                        Type::record("ra", vec![Field::new("fc", Type::Bit, false)]),
+                        false
+                    ),
+                    Field::new(
+                        "fb",
+                        Type::record("rb", vec![Field::new("ff", Type::Bit, false)]),
+                        false
+                    )
+                ]
+            )
+        );
+
+        assert_eq!(
+            rec.split().1.unwrap(),
+            Type::record(
+                "test",
+                vec![
+                    Field::new(
+                        "fa",
+                        Type::record("ra", vec![Field::new("fd", Type::Bit, false)]),
+                        false
+                    ),
+                    Field::new(
+                        "fb",
+                        Type::record("rb", vec![Field::new("fe", Type::Bit, false)]),
+                        false
+                    )
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn split_port() {
+        let (dn, up) = Port::new(
+            "test",
+            Mode::Out,
+            Type::record(
+                "test",
+                vec![
+                    Field::new("a", Type::Bit, false),
+                    Field::new("b", Type::Bit, true),
+                ],
+            ),
+        )
+        .split();
+
+        assert_eq!(
+            dn,
+            Some(Port::new(
+                "test_dn",
+                Mode::Out,
+                Type::record("test_dn", vec![Field::new("a", Type::Bit, false)])
+            ))
+        );
+
+        assert_eq!(
+            up,
+            Some(Port::new(
+                "test_up",
+                Mode::In,
+                Type::record("test_up", vec![Field::new("b", Type::Bit, false)])
+            ))
+        );
+    }
+
+    #[test]
+    fn streamlet_async() {
+        let (_, streamlet) =
+            crate::parser::nom::streamlet("Streamlet test (a : in Bits<1>, b : out Bits<1>)")
+                .unwrap();
+        println!("{}", streamlet.canonical().declare().unwrap());
+        println!("{}", streamlet.user().unwrap().declare().unwrap());
+    }
+
+    #[test]
+    fn streamlet_streams() {
+        let (_, streamlet) = crate::parser::nom::streamlet(
+            "Streamlet test (a : in Stream<Bits<1>>, b : out Stream<Bits<1>>)",
+        )
+        .unwrap();
+        println!("{}", streamlet.canonical().declare().unwrap());
+        println!("{}", streamlet.user().unwrap().declare().unwrap());
+    }
+
+    #[test]
+    fn type_conflict() {
         let t0 = Type::record("a", vec![Field::new("x", Type::Bit, false)]);
         let t1 = Type::record("a", vec![Field::new("y", Type::Bit, false)]);
-        let c = Component {
-            identifier: "test".to_string(),
-            parameters: vec![],
-            ports: vec![Port::new("q", Mode::In, t0), Port::new("r", Mode::Out, t1)],
-        };
+        let c = Component::new(
+            "test",
+            vec![],
+            vec![Port::new("q", Mode::In, t0), Port::new("r", Mode::Out, t1)],
+        );
         let p = Library {
             identifier: "lib".to_string(),
             components: vec![c],
@@ -140,7 +392,7 @@ mod test {
     }
 
     #[test]
-    fn test_backend() -> Result<()> {
+    fn backend() -> Result<()> {
         let v = VHDLBackEnd::default();
 
         let tmpdir = tempfile::tempdir()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,12 @@ impl From<Name> for String {
     }
 }
 
+impl From<&Name> for String {
+    fn from(name: &Name) -> Self {
+        name.0.clone()
+    }
+}
+
 use std::ops::Deref;
 impl Deref for Name {
     type Target = str;

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -328,6 +328,7 @@ impl Group {
         Ok(Group(map))
     }
 
+    /// Returns an iterator over the fields of the Group.
     pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalStreamType)> {
         self.0.iter()
     }
@@ -377,6 +378,27 @@ impl Union {
                 .transpose()?;
         }
         Ok(Union(map))
+    }
+
+    /// Returns the tag name and width of this union.
+    /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html)
+    pub fn tag(&self) -> Option<(String, BitCount)> {
+        if self.0.len() > 1 {
+            Some((
+                "tag".to_string(),
+                BitCount::new(log2_ceil(
+                    BitCount::new(self.0.len() as NonNegative).unwrap(),
+                ))
+                .unwrap(),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over the fields of the Union.
+    pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalStreamType)> {
+        self.0.iter()
     }
 }
 
@@ -785,6 +807,9 @@ pub(crate) struct SplitStreams {
 impl SplitStreams {
     pub fn streams(&self) -> impl Iterator<Item = (&PathName, &LogicalStreamType)> {
         self.streams.iter()
+    }
+    pub fn signal(&self) -> &LogicalStreamType {
+        &self.signals
     }
 }
 

--- a/tests/vhdl.rs
+++ b/tests/vhdl.rs
@@ -1,0 +1,257 @@
+/// Integration tests using the VHDL back-end.
+extern crate tydi;
+
+use tydi::generator::vhdl::Declare;
+use tydi::generator::Componentify;
+use tydi::Name;
+use tydi::UniquelyNamedBuilder;
+
+#[test]
+fn streamlet_async() {
+    let (_, streamlet) =
+        tydi::parser::nom::streamlet("Streamlet test (a : in Bits<1>, b : out Bits<2>)").unwrap();
+    assert_eq!(
+        streamlet.canonical(None).declare().unwrap(),
+        "component test
+  port(
+    a : in std_logic_vector(0 downto 0);
+    b : out std_logic_vector(1 downto 0)
+  );
+end component;"
+    );
+    assert_eq!(
+        streamlet.user(None).unwrap().declare().unwrap(),
+        "component test
+  port(
+    a : in std_logic_vector(0 downto 0);
+    b : out std_logic_vector(1 downto 0)
+  );
+end component;"
+    );
+}
+
+#[test]
+fn streamlet_async_nested() {
+    let (_, streamlet) = tydi::parser::nom::streamlet(
+        "Streamlet test (a : in Group<b: Bits<1>, c: Bits<2>>, d : out Bits<1>)",
+    )
+    .unwrap();
+    let lib = tydi::design::library::Library::from_builder(
+        Name::try_new("test").unwrap(),
+        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+    );
+
+    let lib: tydi::generator::common::Library = lib.unwrap().into();
+    assert_eq!(
+        lib.declare().unwrap(),
+        "package test is
+
+component test_com
+  port(
+    a_b : in std_logic_vector(0 downto 0);
+    a_c : in std_logic_vector(1 downto 0);
+    d : out std_logic_vector(0 downto 0)
+  );
+end component;
+
+record test_a_type
+  b : std_logic_vector(0 downto 0);
+  c : std_logic_vector(1 downto 0);
+end record;
+
+component test
+  port(
+    a : in test_a_type;
+    d : out std_logic_vector(0 downto 0)
+  );
+end component;
+
+end test;"
+    );
+}
+
+#[test]
+fn streamlet_streams() {
+    let (_, streamlet) = tydi::parser::nom::streamlet(
+        "Streamlet test (a : in Stream<Bits<1>>, b : out Stream<Bits<2>, d=2>)",
+    )
+    .unwrap();
+    let lib = tydi::design::library::Library::from_builder(
+        Name::try_new("test").unwrap(),
+        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+    );
+
+    let lib: tydi::generator::common::Library = lib.unwrap().into();
+    assert_eq!(
+        lib.declare().unwrap(),
+        "package test is
+
+component test_com
+  port(
+    a_valid : in std_logic;
+    a_ready : out std_logic;
+    a_data : in std_logic_vector(0 downto 0);
+    b_valid : out std_logic;
+    b_ready : in std_logic;
+    b_data : out std_logic_vector(1 downto 0);
+    b_last : out std_logic_vector(1 downto 0);
+    b_strb : out std_logic_vector(0 downto 0)
+  );
+end component;
+
+record test_a_type
+  valid : std_logic;
+  ready : std_logic;
+  data : std_logic_vector(0 downto 0);
+end record;
+
+record test_b_type
+  valid : std_logic;
+  ready : std_logic;
+  data : std_logic_vector(1 downto 0);
+  last : std_logic_vector(1 downto 0);
+  strb : std_logic_vector(0 downto 0);
+end record;
+
+component test
+  port(
+    a : in test_a_type;
+    b : out test_b_type
+  );
+end component;
+
+end test;"
+    );
+}
+
+#[test]
+fn streamlet_group_async_streams() {
+    let (_, streamlet) = tydi::parser::nom::streamlet(
+        "Streamlet test (a : in Group<b:Bits<2>, c:Stream<Bits<1>>>, d : out Stream<Bits<1>>)",
+    )
+    .unwrap();
+    let lib = tydi::design::library::Library::from_builder(
+        Name::try_new("test").unwrap(),
+        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+    );
+
+    let lib: tydi::generator::common::Library = lib.unwrap().into();
+    assert_eq!(
+        lib.declare().unwrap(),
+        "package test is
+
+component test_com
+  port(
+    a_b : in std_logic_vector(1 downto 0);
+    a_c_valid : in std_logic;
+    a_c_ready : out std_logic;
+    a_c_data : in std_logic_vector(0 downto 0);
+    d_valid : out std_logic;
+    d_ready : in std_logic;
+    d_data : out std_logic_vector(0 downto 0)
+  );
+end component;
+
+record test_a_type
+  b : std_logic_vector(1 downto 0);
+end record;
+
+record test_a_c_type
+  valid : std_logic;
+  ready : std_logic;
+  data : std_logic_vector(0 downto 0);
+end record;
+
+record test_d_type
+  valid : std_logic;
+  ready : std_logic;
+  data : std_logic_vector(0 downto 0);
+end record;
+
+component test
+  port(
+    a : in test_a_type;
+    a_c : in test_a_c_type;
+    d : out test_d_type
+  );
+end component;
+
+end test;"
+    );
+}
+
+#[test]
+fn streamlet_async_all() {
+    let (_, streamlet) = tydi::parser::nom::streamlet(
+        "Streamlet test (
+            a : in Null,
+            b : in Bits<1>,
+            c : in Group<d:Bits<1>, e:Bits<2>>,
+            f : in Union<g:Null, h:Bits<3>>,
+            i : out Group<q:Null, r:Bits<1>, s:Group<t:Bits<1>, u:Bits<2>>, v:Union<g:Null, w:Bits<3>>>
+        )",
+    )
+    .unwrap();
+    let lib = tydi::design::library::Library::from_builder(
+        Name::try_new("test").unwrap(),
+        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+    );
+
+    let lib: tydi::generator::common::Library = lib.unwrap().into();
+    assert_eq!(
+        lib.declare().unwrap(),
+        "package test is
+
+component test_com
+  port(
+    b : in std_logic_vector(0 downto 0);
+    c_d : in std_logic_vector(0 downto 0);
+    c_e : in std_logic_vector(1 downto 0);
+    f_tag : in std_logic_vector(0 downto 0);
+    f_h : in std_logic_vector(2 downto 0);
+    i_r : out std_logic_vector(0 downto 0);
+    i_s_t : out std_logic_vector(0 downto 0);
+    i_s_u : out std_logic_vector(1 downto 0);
+    i_v_tag : out std_logic_vector(0 downto 0);
+    i_v_w : out std_logic_vector(2 downto 0)
+  );
+end component;
+
+record test_c_type
+  d : std_logic_vector(0 downto 0);
+  e : std_logic_vector(1 downto 0);
+end record;
+
+record test_f_type
+  tag : std_logic_vector(0 downto 0);
+  h : std_logic_vector(2 downto 0);
+end record;
+
+record test_i_type
+  r : std_logic_vector(0 downto 0);
+  s : test_i_s_type;
+  v : test_i_v_type;
+end record;
+
+record test_i_s_type
+  t : std_logic_vector(0 downto 0);
+  u : std_logic_vector(1 downto 0);
+end record;
+
+record test_i_v_type
+  tag : std_logic_vector(0 downto 0);
+  w : std_logic_vector(2 downto 0);
+end record;
+
+component test
+  port(
+    b : in std_logic_vector(0 downto 0);
+    c : in test_c_type;
+    f : in test_f_type;
+    i : out test_i_type
+  );
+end component;
+
+end test;"
+    );
+}


### PR DESCRIPTION
Improves the VHDL back-end with the recent changes to the common module and generators.
Introduces some integration tests that take a SDF and convert it all the way down to VHDL code, that can be checked.