### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,0 +1,89 @@
+name: Assets
+
+on:
+  release:
+    types:
+    - created
+
+env:
+  ARGS: --release --bin tydi --features=cli
+
+jobs:
+  darwin:
+    name: Darwin
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: $ARGS
+    - name: Create archive
+      run: tar -czf tydi-${{ github.event.release.tag_name }}-x86_64-apple-darwin.tar.gz target/release/tydi
+    - uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: tydi-${{ github.event.release.tag_name }}-x86_64-apple-darwin.tar.gz
+        asset_name: tydi-${{ github.event.release.tag_name }}-x86_64-apple-darwin.tar.gz
+        asset_content_type: application/gzip
+
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - x86_64-pc-windows-gnu
+          - powerpc64le-unknown-linux-gnu
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: $ARGS --target ${{ matrix.target }}
+        use-cross: true
+    - name: Create archive
+      run: tar -czf tydi-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz target/${{ matrix.target }}/release/tydi
+    - uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: tydi-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz
+        asset_name: tydi-${{ github.event.release.tag_name }}-${{ matrix.target }}.tar.gz
+        asset_content_type: application/gzip
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: $ARGS
+    - name: Create archive
+      run: Compress-Archive target\release\tydi.exe tydi-${{ github.event.release.tag_name }}-x86_64-pc-windows-gnu.zip
+    - uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: tydi-${{ github.event.release.tag_name }}-x86_64-pc-windows-gnu.zip
+        asset_name: tydi-${{ github.event.release.tag_name }}-x86_64-pc-windows-gnu.zip
+        asset_content_type: application/zip

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -29,7 +29,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '**'
+
+jobs:
+  github:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+
+  crates:
+    name: Crates.io
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - uses: actions-rs/cargo@v1.0.1
+      with:
+        command: publish
+        args: --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
 
   rustfmt:
     name: Rustfmt
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -59,7 +59,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
For now this just creates a GitHub release and publishes the `tydi` crate to Crates.io when tags are pushed. We can add uploads of binary assets and other packaging later.