### PR TITLE
Have user-friendly part of back-end produce records with names as in examples and spec.

### DIFF
--- a/src/generator/common.rs
+++ b/src/generator/common.rs
@@ -50,6 +50,23 @@ impl Identify for Array {
 }
 
 /// A field for a `Record`.
+///
+/// A field may be "reversed" with respect to the other fields in the record.
+/// This means that when the type is used to describe a connection between an input and output port
+/// of some component, this field will have its port modes swapped.
+///
+/// # Example:
+/// ```
+/// use tydi::generator::common::{Port, Mode, Record, Field, Type};
+///
+/// let port = Port::new("example",
+///     Mode::In,
+///     Type::record("rec", vec![              // Shortcut to Type::Record(Record::new(...
+///         Field::new("a", Type::Bit, false), // This field will have a port Mode::In
+///         Field::new("b", Type::Bit, true)   // This field will have a port Mode::Out
+///     ])
+/// );
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Field {
     /// Name of the field.
@@ -77,10 +94,12 @@ impl Field {
         }
     }
 
+    /// Returns the type of this field.
     pub fn typ(&self) -> &Type {
         &self.typ
     }
 
+    /// Returns true if this field is reversed.
     pub fn is_reversed(&self) -> bool {
         self.reversed
     }
@@ -278,6 +297,7 @@ pub struct Port {
 }
 
 impl Port {
+    /// Create a new port.
     pub fn new(name: impl Into<String>, mode: Mode, typ: Type) -> Port {
         Port {
             identifier: name.into(),
@@ -286,14 +306,17 @@ impl Port {
         }
     }
 
+    /// Return the port mode.
     pub fn mode(&self) -> Mode {
         self.mode
     }
 
+    /// Return the type of the port.
     pub fn typ(&self) -> Type {
         self.typ.clone()
     }
 
+    /// Returns true if the port type contains reversed fields.
     pub fn has_reversed(&self) -> bool {
         self.typ.has_reversed()
     }
@@ -323,6 +346,7 @@ impl Identify for Component {
 }
 
 impl Component {
+    /// Create a new component.
     pub fn new(
         identifier: impl Into<String>,
         parameters: Vec<Parameter>,
@@ -335,10 +359,12 @@ impl Component {
         }
     }
 
+    /// Return a reference to the ports of this component.
     pub fn ports(&self) -> &Vec<Port> {
         &self.ports
     }
 
+    /// Return a reference to the parameters of this component.
     pub fn parameters(&self) -> &Vec<Parameter> {
         &self.parameters
     }
@@ -397,7 +423,7 @@ pub(crate) mod test {
 
         pub(crate) fn rec(name: impl Into<String>) -> Type {
             Type::record(
-                cat!(name.into(), "type"),
+                name.into(),
                 vec![
                     Field::new("a", Type::bitvec(42), false),
                     Field::new("b", Type::bitvec(1337), false),
@@ -406,18 +432,15 @@ pub(crate) mod test {
         }
 
         pub(crate) fn rec_of_single(name: impl Into<String>) -> Type {
-            Type::record(
-                cat!(name.into(), "type"),
-                vec![Field::new("a", Type::bitvec(42), false)],
-            )
+            Type::record(name.into(), vec![Field::new("a", Type::bitvec(42), false)])
         }
 
         pub(crate) fn rec_nested(name: impl Into<String>) -> Type {
             let n: String = name.into();
             Type::record(
-                cat!(n, "type"),
+                n.clone(),
                 vec![
-                    Field::new("c", rec(cat!(n, "c")), false),
+                    Field::new("c", rec(cat!(n.clone(), "c")), false),
                     Field::new("d", rec(cat!(n, "d")), false),
                 ],
             )

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -515,7 +515,7 @@ pub(crate) mod tests {
             assert_eq!(
                 typ0,
                 Type::record(
-                    "test_type",
+                    "test",
                     vec![
                         Field::new("valid", Type::Bit, false),
                         Field::new("ready", Type::Bit, true),
@@ -528,12 +528,12 @@ pub(crate) mod tests {
             assert_eq!(
                 typ1,
                 Type::record(
-                    "test_type",
+                    "test",
                     vec![
                         Field::new(
                             "a",
                             Type::record(
-                                "test_a_type",
+                                "test_a",
                                 vec![
                                     Field::new("valid", Type::Bit, false),
                                     Field::new("ready", Type::Bit, true),
@@ -545,7 +545,7 @@ pub(crate) mod tests {
                         Field::new(
                             "b",
                             Type::record(
-                                "test_b_type",
+                                "test_b",
                                 vec![
                                     Field::new("valid", Type::Bit, false),
                                     Field::new("ready", Type::Bit, true),

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -110,7 +110,7 @@ impl Typify for LogicalStreamType {
 impl Typify for Group {
     fn user(&self, prefix: impl Into<String>) -> Option<Type> {
         let n: String = prefix.into();
-        let mut rec = Record::new_empty(cat!(n.clone(), "type"));
+        let mut rec = Record::new_empty(n.clone());
         for (field_name, field_logical) in self.iter() {
             if let Some(field_common_type) = field_logical.user(cat!(n.clone(), field_name)) {
                 rec.insert_new_field(field_name.to_string(), field_common_type, false)
@@ -133,7 +133,7 @@ impl Typify for Group {
 impl Typify for Union {
     fn user(&self, prefix: impl Into<String>) -> Option<Type> {
         let n: String = prefix.into();
-        let mut rec = Record::new_empty(cat!(n.clone(), "type"));
+        let mut rec = Record::new_empty(n.clone());
         if let Some((tag_name, tag_bc)) = self.tag() {
             rec.insert_new_field(tag_name, Type::bitvec(tag_bc.get()), false);
         }
@@ -188,8 +188,8 @@ impl Typify for Stream {
 
             // Set up the resulting record.
             let mut rec = Record::new_empty_stream(match name.len() {
-                0 => cat!(prefix.into(), "type"),
-                _ => cat!(prefix.into(), name, "type"),
+                0 => prefix.into(),
+                _ => cat!(prefix.into(), name),
             });
 
             // Insert data record. There must be something there since it is not null.

--- a/src/generator/vhdl/mod.rs
+++ b/src/generator/vhdl/mod.rs
@@ -17,10 +17,16 @@ use structopt::StructOpt;
 
 mod impls;
 
-/// Generate trait for VHDL declarations.
+/// Generate trait for generic VHDL declarations.
 pub trait Declare {
     /// Generate a VHDL declaration from self.
     fn declare(&self) -> Result<String>;
+}
+
+/// Generate trait for VHDL type declarations.
+pub trait DeclareType {
+    /// Generate a VHDL declaration from self.
+    fn declare(&self, is_root_type: bool) -> Result<String>;
 }
 
 /// Generate trait for VHDL identifiers.

--- a/tests/vhdl.rs
+++ b/tests/vhdl.rs
@@ -1,50 +1,53 @@
 /// Integration tests using the VHDL back-end.
 extern crate tydi;
 
-use tydi::generator::vhdl::Declare;
-use tydi::generator::Componentify;
-use tydi::Name;
-use tydi::UniquelyNamedBuilder;
+#[cfg(test)]
+mod tests {
+    use tydi::generator::vhdl::Declare;
+    use tydi::generator::Componentify;
+    use tydi::Name;
+    use tydi::UniquelyNamedBuilder;
 
-#[test]
-fn streamlet_async() {
-    let (_, streamlet) =
-        tydi::parser::nom::streamlet("Streamlet test (a : in Bits<1>, b : out Bits<2>)").unwrap();
-    assert_eq!(
-        streamlet.canonical(None).declare().unwrap(),
-        "component test
+    #[test]
+    fn streamlet_async() {
+        let (_, streamlet) =
+            tydi::parser::nom::streamlet("Streamlet test (a : in Bits<1>, b : out Bits<2>)")
+                .unwrap();
+        assert_eq!(
+            streamlet.canonical(None).declare().unwrap(),
+            "component test
   port(
     a : in std_logic_vector(0 downto 0);
     b : out std_logic_vector(1 downto 0)
   );
 end component;"
-    );
-    assert_eq!(
-        streamlet.user(None).unwrap().declare().unwrap(),
-        "component test
+        );
+        assert_eq!(
+            streamlet.user(None).unwrap().declare().unwrap(),
+            "component test
   port(
     a : in std_logic_vector(0 downto 0);
     b : out std_logic_vector(1 downto 0)
   );
 end component;"
-    );
-}
+        );
+    }
 
-#[test]
-fn streamlet_async_nested() {
-    let (_, streamlet) = tydi::parser::nom::streamlet(
-        "Streamlet test (a : in Group<b: Bits<1>, c: Bits<2>>, d : out Bits<1>)",
-    )
-    .unwrap();
-    let lib = tydi::design::library::Library::from_builder(
-        Name::try_new("test").unwrap(),
-        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
-    );
+    #[test]
+    fn streamlet_async_nested() {
+        let (_, streamlet) = tydi::parser::nom::streamlet(
+            "Streamlet test (a : in Group<b: Bits<1>, c: Bits<2>>, d : out Bits<1>)",
+        )
+        .unwrap();
+        let lib = tydi::design::library::Library::from_builder(
+            Name::try_new("test").unwrap(),
+            UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+        );
 
-    let lib: tydi::generator::common::Library = lib.unwrap().into();
-    assert_eq!(
-        lib.declare().unwrap(),
-        "package test is
+        let lib: tydi::generator::common::Library = lib.unwrap().into();
+        assert_eq!(
+            lib.declare().unwrap(),
+            "package test is
 
 component test_com
   port(
@@ -67,24 +70,24 @@ component test
 end component;
 
 end test;"
-    );
-}
+        );
+    }
 
-#[test]
-fn streamlet_streams() {
-    let (_, streamlet) = tydi::parser::nom::streamlet(
-        "Streamlet test (a : in Stream<Bits<1>>, b : out Stream<Bits<2>, d=2>)",
-    )
-    .unwrap();
-    let lib = tydi::design::library::Library::from_builder(
-        Name::try_new("test").unwrap(),
-        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
-    );
+    #[test]
+    fn streamlet_streams() {
+        let (_, streamlet) = tydi::parser::nom::streamlet(
+            "Streamlet test (a : in Stream<Bits<1>>, b : out Stream<Bits<2>, d=2>)",
+        )
+        .unwrap();
+        let lib = tydi::design::library::Library::from_builder(
+            Name::try_new("test").unwrap(),
+            UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+        );
 
-    let lib: tydi::generator::common::Library = lib.unwrap().into();
-    assert_eq!(
-        lib.declare().unwrap(),
-        "package test is
+        let lib: tydi::generator::common::Library = lib.unwrap().into();
+        assert_eq!(
+            lib.declare().unwrap(),
+            "package test is
 
 component test_com
   port(
@@ -99,46 +102,54 @@ component test_com
   );
 end component;
 
-record test_a_type
+record test_a_dn_type
   valid : std_logic;
-  ready : std_logic;
   data : std_logic_vector(0 downto 0);
 end record;
 
-record test_b_type
-  valid : std_logic;
+record test_a_up_type
   ready : std_logic;
+end record;
+
+record test_b_dn_type
+  valid : std_logic;
   data : std_logic_vector(1 downto 0);
   last : std_logic_vector(1 downto 0);
   strb : std_logic_vector(0 downto 0);
 end record;
 
+record test_b_up_type
+  ready : std_logic;
+end record;
+
 component test
   port(
-    a : in test_a_type;
-    b : out test_b_type
+    a_dn : in test_a_dn_type;
+    a_up : out test_a_up_type;
+    b_dn : out test_b_dn_type;
+    b_up : in test_b_up_type
   );
 end component;
 
 end test;"
-    );
-}
+        );
+    }
 
-#[test]
-fn streamlet_group_async_streams() {
-    let (_, streamlet) = tydi::parser::nom::streamlet(
-        "Streamlet test (a : in Group<b:Bits<2>, c:Stream<Bits<1>>>, d : out Stream<Bits<1>>)",
-    )
-    .unwrap();
-    let lib = tydi::design::library::Library::from_builder(
-        Name::try_new("test").unwrap(),
-        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
-    );
+    #[test]
+    fn streamlet_group_async_streams() {
+        let (_, streamlet) = tydi::parser::nom::streamlet(
+            "Streamlet test (a : in Group<b:Bits<2>, c:Stream<Bits<1>>>, d : out Stream<Bits<1>>)",
+        )
+        .unwrap();
+        let lib = tydi::design::library::Library::from_builder(
+            Name::try_new("test").unwrap(),
+            UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+        );
 
-    let lib: tydi::generator::common::Library = lib.unwrap().into();
-    assert_eq!(
-        lib.declare().unwrap(),
-        "package test is
+        let lib: tydi::generator::common::Library = lib.unwrap().into();
+        assert_eq!(
+            lib.declare().unwrap(),
+            "package test is
 
 component test_com
   port(
@@ -156,51 +167,59 @@ record test_a_type
   b : std_logic_vector(1 downto 0);
 end record;
 
-record test_a_c_type
+record test_a_c_dn_type
   valid : std_logic;
-  ready : std_logic;
   data : std_logic_vector(0 downto 0);
 end record;
 
-record test_d_type
-  valid : std_logic;
+record test_a_c_up_type
   ready : std_logic;
+end record;
+
+record test_d_dn_type
+  valid : std_logic;
   data : std_logic_vector(0 downto 0);
+end record;
+
+record test_d_up_type
+  ready : std_logic;
 end record;
 
 component test
   port(
     a : in test_a_type;
-    a_c : in test_a_c_type;
-    d : out test_d_type
+    a_c_dn : in test_a_c_dn_type;
+    a_c_up : out test_a_c_up_type;
+    d_dn : out test_d_dn_type;
+    d_up : in test_d_up_type
   );
 end component;
 
 end test;"
-    );
-}
+        );
+    }
 
-#[test]
-fn streamlet_async_all() {
-    let (_, streamlet) = tydi::parser::nom::streamlet(
-        "Streamlet test (
+    #[test]
+    fn streamlet_async_all() {
+        let (_, streamlet) = tydi::parser::nom::streamlet(
+            "Streamlet test (
             a : in Null,
             b : in Bits<1>,
             c : in Group<d:Bits<1>, e:Bits<2>>,
             f : in Union<g:Null, h:Bits<3>>,
             i : out Group<q:Null, r:Bits<1>, s:Group<t:Bits<1>, u:Bits<2>>, v:Union<g:Null, w:Bits<3>>>
         )",
-    )
-    .unwrap();
-    let lib = tydi::design::library::Library::from_builder(
-        Name::try_new("test").unwrap(),
-        UniquelyNamedBuilder::new().with_items(vec![streamlet]),
-    );
+        )
+            .unwrap();
+        let lib = tydi::design::library::Library::from_builder(
+            Name::try_new("test").unwrap(),
+            UniquelyNamedBuilder::new().with_items(vec![streamlet]),
+        );
 
-    let lib: tydi::generator::common::Library = lib.unwrap().into();
-    assert_eq!(
-        lib.declare().unwrap(),
-        "package test is
+        let lib: tydi::generator::common::Library = lib.unwrap().into();
+        assert_eq!(
+            lib.declare().unwrap(),
+            "package test is
 
 component test_com
   port(
@@ -253,5 +272,6 @@ component test
 end component;
 
 end test;"
-    );
+        );
+    }
 }


### PR DESCRIPTION
This PR will work on wrapping a reference user-friendly component in a canonical component for the VHDL back-end.

- [x] Have user-friendly part of back-end produce records with names as in examples and spec.
- [ ] Implement connections in Common layer.
- [ ] Add tests

Edit: Doing the actual connections has been postponed for a while, so I'll merge the fixes in this for now, and work on the connections in another PR.