### PR TITLE
Add type safe iterators for splitted logical streams

### DIFF
--- a/src/design/streamlet.rs
+++ b/src/design/streamlet.rs
@@ -1,8 +1,8 @@
 //! This module contains the Streamlet structure.
 //!
-//! A streamlet is a component where every [Interface] has a [LogicalStreamType].
+//! A streamlet is a component where every [Interface] has a [LogicalType].
 
-use crate::logical::LogicalStreamType;
+use crate::logical::LogicalType;
 use crate::traits::Identify;
 use crate::util::UniquelyNamedBuilder;
 use crate::{Document, Error, Name, Result};
@@ -83,7 +83,7 @@ impl FromStr for Mode {
 pub struct Interface {
     name: Name,
     mode: Mode,
-    typ: LogicalStreamType,
+    typ: LogicalType,
     doc: Option<String>,
 }
 
@@ -92,7 +92,7 @@ impl Interface {
         self.mode
     }
 
-    pub fn typ(&self) -> LogicalStreamType {
+    pub fn typ(&self) -> LogicalType {
         self.typ.clone()
     }
 }
@@ -107,13 +107,13 @@ impl Interface {
     pub fn try_new(
         name: impl TryInto<Name, Error = impl Into<Box<dyn std::error::Error>>>,
         mode: Mode,
-        typ: impl TryInto<LogicalStreamType, Error = impl Into<Box<dyn std::error::Error>>>,
+        typ: impl TryInto<LogicalType, Error = impl Into<Box<dyn std::error::Error>>>,
         doc: Option<String>,
     ) -> Result<Self> {
         let n: Name = name
             .try_into()
             .map_err(|e| Error::InterfaceError(e.into().to_string()))?;
-        let t: LogicalStreamType = typ
+        let t: LogicalType = typ
             .try_into()
             .map_err(|e| Error::InterfaceError(e.into().to_string()))?;
         match n.to_string().as_str() {
@@ -151,8 +151,8 @@ pub mod tests {
             Streamlet::from_builder(
                 Name::try_new(name).unwrap(),
                 UniquelyNamedBuilder::new().with_items(vec![
-                    Interface::try_new("a", Mode::In, LogicalStreamType::Null, None).unwrap(),
-                    Interface::try_new("b", Mode::Out, LogicalStreamType::Null, None).unwrap(),
+                    Interface::try_new("a", Mode::In, LogicalType::Null, None).unwrap(),
+                    Interface::try_new("b", Mode::Out, LogicalType::Null, None).unwrap(),
                 ]),
                 None,
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,11 +282,18 @@ impl PathName {
         self.0.push(name.into())
     }
 
+    pub(crate) fn with_parents(&self, path: impl Into<PathName>) -> PathName {
+        let parent = path.into();
+        let mut result: Vec<Name> = Vec::with_capacity(self.len() + parent.len());
+        result.extend(parent.0.into_iter());
+        result.extend(self.0.clone().into_iter());
+        PathName::new(result.into_iter())
+    }
+
     pub(crate) fn with_parent(&self, name: impl Into<Name>) -> PathName {
         let mut result: Vec<Name> = Vec::with_capacity(self.len() + 1);
         result.push(name.into());
-        let mut names = self.0.clone().into_iter();
-        result.extend(&mut names);
+        result.extend(self.0.clone().into_iter());
         PathName::new(result.into_iter())
     }
 
@@ -321,6 +328,12 @@ impl fmt::Display for PathName {
             result.push_str("");
         }
         write!(f, "{}", result)
+    }
+}
+
+impl AsRef<[Name]> for PathName {
+    fn as_ref(&self) -> &[Name] {
+        self.0.as_slice()
     }
 }
 

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -1024,16 +1024,16 @@ pub(crate) mod tests {
             LogicalType::try_new_bits(bits).unwrap()
         }
 
-        pub(crate) fn group() -> LogicalStreamType {
-            LogicalStreamType::try_new_group(vec![("c", prim(42)), ("d", prim(1337))]).unwrap()
+        pub(crate) fn group() -> LogicalType {
+            LogicalType::try_new_group(vec![("c", prim(42)), ("d", prim(1337))]).unwrap()
         }
 
         pub(crate) fn group_of_single() -> LogicalType {
             LogicalType::try_new_group(vec![("a", prim(42))]).unwrap()
         }
 
-        pub(crate) fn group_nested() -> LogicalStreamType {
-            LogicalStreamType::try_new_group(vec![("a", group()), ("b", group())]).unwrap()
+        pub(crate) fn group_nested() -> LogicalType {
+            LogicalType::try_new_group(vec![("a", group()), ("b", group())]).unwrap()
         }
     }
 
@@ -1085,7 +1085,7 @@ pub(crate) mod tests {
             vec![group.fields()]
         );
 
-        let needle: PathName = "a".try_into()?;
+        let needle: PathName = "c".try_into()?;
         let nested =
             LogicalType::try_new_group(vec![("in", stream.clone()), ("out", stream)]).unwrap();
         assert_eq!(

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -138,7 +138,7 @@ pub struct Stream {
     ///
     /// Any logical stream type representing the data type carried by the
     /// logical stream.
-    data: Box<LogicalStreamType>,
+    data: Box<LogicalType>,
     /// Throughput ratio of the stream.
     ///
     /// Positive real number, representing the minimum number of elements that
@@ -173,7 +173,7 @@ pub struct Stream {
     /// An optional logical stream type consisting of only
     /// element-manipulating nodes, representing the user data carried by
     /// this logical stream.
-    user: Option<Box<LogicalStreamType>>,
+    user: Option<Box<LogicalType>>,
     /// Stream carries extra information.
     ///
     /// Keep specifies whether the stream carries "extra" information
@@ -199,13 +199,13 @@ impl Reverse for Stream {
 impl Stream {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        data: LogicalStreamType,
+        data: LogicalType,
         throughput: PositiveReal,
         dimensionality: NonNegative,
         synchronicity: Synchronicity,
         complexity: impl Into<Complexity>,
         direction: Direction,
-        user: Option<LogicalStreamType>,
+        user: Option<LogicalType>,
         keep: bool,
     ) -> Self {
         Stream {
@@ -220,7 +220,7 @@ impl Stream {
         }
     }
 
-    pub fn new_basic(data: LogicalStreamType) -> Self {
+    pub fn new_basic(data: LogicalType) -> Self {
         Stream {
             data: Box::new(data),
             throughput: PositiveReal::new(1.).unwrap(),
@@ -233,7 +233,7 @@ impl Stream {
         }
     }
 
-    pub fn data(&self) -> &LogicalStreamType {
+    pub fn data(&self) -> &LogicalType {
         &self.data
     }
 
@@ -282,12 +282,12 @@ impl Stream {
     }
 }
 
-impl From<Stream> for LogicalStreamType {
-    /// Wraps this stream in a [`LogicalStreamType`].
+impl From<Stream> for LogicalType {
+    /// Wraps this stream in a [`LogicalType`].
     ///
-    /// [`LogicalStreamType`]: ./enum.LogicalStreamType.html
+    /// [`LogicalType`]: ./enum.LogicalType.html
     fn from(stream: Stream) -> Self {
-        LogicalStreamType::Stream(stream)
+        LogicalType::Stream(stream)
     }
 }
 
@@ -295,7 +295,7 @@ impl From<Stream> for LogicalStreamType {
 ///
 /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html#group)
 #[derive(Debug, Clone, PartialEq)]
-pub struct Group(IndexMap<Name, LogicalStreamType>);
+pub struct Group(IndexMap<Name, LogicalType>);
 
 impl Group {
     /// Returns a new Group logical stream type. Returns an error when either
@@ -305,7 +305,7 @@ impl Group {
         group: impl IntoIterator<
             Item = (
                 impl TryInto<Name, Error = impl Into<Box<dyn error::Error>>>,
-                impl TryInto<LogicalStreamType, Error = impl Into<Box<dyn error::Error>>>,
+                impl TryInto<LogicalType, Error = impl Into<Box<dyn error::Error>>>,
             ),
         >,
     ) -> Result<Self> {
@@ -329,17 +329,17 @@ impl Group {
     }
 
     /// Returns an iterator over the fields of the Group.
-    pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalStreamType)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalType)> {
         self.0.iter()
     }
 }
 
-impl From<Group> for LogicalStreamType {
-    /// Wraps this group in a [`LogicalStreamType`].
+impl From<Group> for LogicalType {
+    /// Wraps this group in a [`LogicalType`].
     ///
-    /// [`LogicalStreamType`]: ./enum.LogicalStreamType.html
+    /// [`LogicalType`]: ./enum.LogicalType.html
     fn from(group: Group) -> Self {
-        LogicalStreamType::Group(group)
+        LogicalType::Group(group)
     }
 }
 
@@ -347,7 +347,7 @@ impl From<Group> for LogicalStreamType {
 ///
 /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html#union)
 #[derive(Debug, Clone, PartialEq)]
-pub struct Union(IndexMap<Name, LogicalStreamType>);
+pub struct Union(IndexMap<Name, LogicalType>);
 
 impl Union {
     /// Returns a new Union logical stream type. Returns an error when either
@@ -357,7 +357,7 @@ impl Union {
         union: impl IntoIterator<
             Item = (
                 impl TryInto<Name, Error = impl Into<Box<dyn error::Error>>>,
-                impl TryInto<LogicalStreamType, Error = impl Into<Box<dyn error::Error>>>,
+                impl TryInto<LogicalType, Error = impl Into<Box<dyn error::Error>>>,
             ),
         >,
     ) -> Result<Self> {
@@ -397,17 +397,17 @@ impl Union {
     }
 
     /// Returns an iterator over the fields of the Union.
-    pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalStreamType)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Name, &LogicalType)> {
         self.0.iter()
     }
 }
 
-impl From<Union> for LogicalStreamType {
-    /// Wraps this union in a [`LogicalStreamType`].
+impl From<Union> for LogicalType {
+    /// Wraps this union in a [`LogicalType`].
     ///
-    /// [`LogicalStreamType`]: ./enum.LogicalStreamType.html
+    /// [`LogicalType`]: ./enum.LogicalType.html
     fn from(union: Union) -> Self {
-        LogicalStreamType::Union(union)
+        LogicalType::Union(union)
     }
 }
 
@@ -429,7 +429,7 @@ impl From<Union> for LogicalStreamType {
 ///
 /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html#logical-stream-type)
 #[derive(Debug, Clone, PartialEq)]
-pub enum LogicalStreamType {
+pub enum LogicalType {
     /// The Null stream type indicates the transferrence of one-valued data: it
     /// is only valid value is ∅ (null).
     ///
@@ -455,43 +455,42 @@ pub enum LogicalStreamType {
     Stream(Stream),
 }
 
-impl TryFrom<NonNegative> for LogicalStreamType {
+impl TryFrom<NonNegative> for LogicalType {
     type Error = Error;
 
     /// Returns a new Bits stream type with the provided bit count as number of
     /// bits. Returns an error when the bit count is zero.
     fn try_from(bit_count: NonNegative) -> Result<Self> {
-        LogicalStreamType::try_new_bits(bit_count)
+        LogicalType::try_new_bits(bit_count)
     }
 }
 
-impl From<Positive> for LogicalStreamType {
+impl From<Positive> for LogicalType {
     fn from(bit_count: Positive) -> Self {
-        LogicalStreamType::Bits(bit_count)
+        LogicalType::Bits(bit_count)
     }
 }
 
-impl LogicalStreamType {
+impl LogicalType {
     /// Returns a new Bits stream type with the provided bit count as number of
     /// bits. Returns an error when the bit count is zero.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tydi::{Error, logical::LogicalStreamType, Positive};
+    /// use tydi::{Error, logical::LogicalType, Positive};
     ///
-    /// let bits = LogicalStreamType::try_new_bits(4);
-    /// let zero = LogicalStreamType::try_new_bits(0);
+    /// let bits = LogicalType::try_new_bits(4);
+    /// let zero = LogicalType::try_new_bits(0);
     ///
-    /// assert_eq!(bits, Ok(LogicalStreamType::Bits(Positive::new(4).unwrap())));
+    /// assert_eq!(bits, Ok(LogicalType::Bits(Positive::new(4).unwrap())));
     /// assert_eq!(zero, Err(Error::InvalidArgument("bit count cannot be zero".to_string())));
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn try_new_bits(bit_count: NonNegative) -> Result<Self> {
-        Ok(LogicalStreamType::Bits(
-            Positive::new(bit_count)
-                .ok_or_else(|| Error::InvalidArgument("bit count cannot be zero".to_string()))?,
-        ))
+        Ok(LogicalType::Bits(Positive::new(bit_count).ok_or_else(
+            || Error::InvalidArgument("bit count cannot be zero".to_string()),
+        )?))
     }
 
     /// Returns a new Group stream type from the provided iterator of names and
@@ -501,26 +500,26 @@ impl LogicalStreamType {
     /// # Examples
     ///
     /// ```rust
-    /// use tydi::{Error, logical::{Group, LogicalStreamType}};
+    /// use tydi::{Error, logical::{Group, LogicalType}};
     ///
-    /// let group = LogicalStreamType::try_new_group(
+    /// let group = LogicalType::try_new_group(
     ///     vec![
-    ///         ("a", 4), // TryFrom<NonNegative> for LogicalStreamType::Bits.
+    ///         ("a", 4), // TryFrom<NonNegative> for LogicalType::Bits.
     ///         ("b", 12),
     ///     ]
     /// )?;
     ///
     /// assert!(match group {
-    ///     LogicalStreamType::Group(_) => true,
+    ///     LogicalType::Group(_) => true,
     ///     _ => false,
     /// });
     ///
     /// assert_eq!(
-    ///     LogicalStreamType::try_new_group(vec![("1badname", 4)]),
+    ///     LogicalType::try_new_group(vec![("1badname", 4)]),
     ///     Err(Error::InvalidArgument("name cannot start with a digit".to_string()))
     /// );
     /// assert_eq!(
-    ///     LogicalStreamType::try_new_group(vec![("good_name", 0)]),
+    ///     LogicalType::try_new_group(vec![("good_name", 0)]),
     ///     Err(Error::InvalidArgument("bit count cannot be zero".to_string()))
     /// );
     ///
@@ -532,7 +531,7 @@ impl LogicalStreamType {
         group: impl IntoIterator<
             Item = (
                 impl TryInto<Name, Error = impl Into<Box<dyn error::Error>>>,
-                impl TryInto<LogicalStreamType, Error = impl Into<Box<dyn error::Error>>>,
+                impl TryInto<LogicalType, Error = impl Into<Box<dyn error::Error>>>,
             ),
         >,
     ) -> Result<Self> {
@@ -543,7 +542,7 @@ impl LogicalStreamType {
         union: impl IntoIterator<
             Item = (
                 impl TryInto<Name, Error = impl Into<Box<dyn error::Error>>>,
-                impl TryInto<LogicalStreamType, Error = impl Into<Box<dyn error::Error>>>,
+                impl TryInto<LogicalType, Error = impl Into<Box<dyn error::Error>>>,
             ),
         >,
     ) -> Result<Self> {
@@ -557,20 +556,20 @@ impl LogicalStreamType {
     /// # Examples
     ///
     /// ```rust
-    /// use tydi::logical::LogicalStreamType;
+    /// use tydi::logical::LogicalType;
     ///
-    /// assert!(LogicalStreamType::Null.is_element_only());
-    /// assert!(LogicalStreamType::try_new_bits(3)?.is_element_only());
+    /// assert!(LogicalType::Null.is_element_only());
+    /// assert!(LogicalType::try_new_bits(3)?.is_element_only());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn is_element_only(&self) -> bool {
         match self {
-            LogicalStreamType::Null | LogicalStreamType::Bits(_) => true,
-            LogicalStreamType::Group(Group(fields)) | LogicalStreamType::Union(Union(fields)) => {
+            LogicalType::Null | LogicalType::Bits(_) => true,
+            LogicalType::Group(Group(fields)) | LogicalType::Union(Union(fields)) => {
                 fields.values().all(|stream| stream.is_element_only())
             }
-            LogicalStreamType::Stream(stream) => stream.data.is_element_only(),
+            LogicalType::Stream(stream) => stream.data.is_element_only(),
         }
     }
 
@@ -580,27 +579,25 @@ impl LogicalStreamType {
     /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html#null-detection-function)
     pub fn is_null(&self) -> bool {
         match self {
-            LogicalStreamType::Null => true,
-            LogicalStreamType::Group(Group(fields)) => {
-                fields.values().all(|stream| stream.is_null())
-            }
-            LogicalStreamType::Union(Union(fields)) => {
+            LogicalType::Null => true,
+            LogicalType::Group(Group(fields)) => fields.values().all(|stream| stream.is_null()),
+            LogicalType::Union(Union(fields)) => {
                 fields.len() == 1 && fields.values().all(|stream| stream.is_null())
             }
-            LogicalStreamType::Stream(stream) => stream.is_null(),
-            LogicalStreamType::Bits(_) => false,
+            LogicalType::Stream(stream) => stream.is_null(),
+            LogicalType::Bits(_) => false,
         }
     }
 
     /// Splits a logical stream type into simplified stream types.
     ///
     /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html#split-function)
-    pub(crate) fn split(&self) -> SplitStreams {
+    pub(crate) fn split_streams(&self) -> SplitStreams {
         match self {
-            LogicalStreamType::Stream(stream_in) => {
+            LogicalType::Stream(stream_in) => {
                 let mut streams = IndexMap::new();
 
-                let split = stream_in.data.split();
+                let split = stream_in.data.split_streams();
                 let (element, rest) = (split.signals, split.streams);
                 if !element.is_null()
                     || (stream_in.user.is_some() && !stream_in.user.as_ref().unwrap().is_null())
@@ -624,7 +621,7 @@ impl LogicalStreamType {
                 }
 
                 streams.extend(rest.into_iter().map(|(name, stream)| match stream {
-                    LogicalStreamType::Stream(mut stream) => {
+                    LogicalType::Stream(mut stream) => {
                         if stream_in.direction == Direction::Reverse {
                             stream.reverse();
                         }
@@ -647,30 +644,30 @@ impl LogicalStreamType {
                 }));
 
                 SplitStreams {
-                    signals: LogicalStreamType::Null,
+                    signals: LogicalType::Null,
                     streams,
                 }
             }
-            LogicalStreamType::Null | LogicalStreamType::Bits(_) => SplitStreams {
+            LogicalType::Null | LogicalType::Bits(_) => SplitStreams {
                 signals: self.clone(),
                 streams: IndexMap::new(),
             },
-            LogicalStreamType::Group(Group(fields)) | LogicalStreamType::Union(Union(fields)) => {
+            LogicalType::Group(Group(fields)) | LogicalType::Union(Union(fields)) => {
                 let signals = fields
                     .into_iter()
-                    .map(|(name, stream)| (name.clone(), stream.split().signals))
+                    .map(|(name, stream)| (name.clone(), stream.split_streams().signals))
                     .collect();
 
                 SplitStreams {
                     signals: match self {
-                        LogicalStreamType::Group(_) => LogicalStreamType::Group(Group(signals)),
-                        LogicalStreamType::Union(_) => LogicalStreamType::Union(Union(signals)),
+                        LogicalType::Group(_) => LogicalType::Group(Group(signals)),
+                        LogicalType::Union(_) => LogicalType::Union(Union(signals)),
                         _ => unreachable!(),
                     },
                     streams: fields
                         .into_iter()
                         .map(|(name, stream)| {
-                            stream.split().streams.into_iter().map(
+                            stream.split_streams().streams.into_iter().map(
                                 move |(mut path_name, stream_)| {
                                     path_name.push(name.clone());
                                     (path_name, stream_)
@@ -690,15 +687,15 @@ impl LogicalStreamType {
     /// [Reference](https://abs-tudelft.github.io/tydi/specification/logical.html#field-conversion-function)
     ///
     /// [`Fields`]: ./struct.Fields.html
-    pub fn fields(&self) -> Fields {
+    pub(crate) fn fields(&self) -> Fields {
         let mut fields = Fields::new_empty();
         match self {
-            LogicalStreamType::Null | LogicalStreamType::Stream(_) => fields,
-            LogicalStreamType::Bits(b) => {
+            LogicalType::Null | LogicalType::Stream(_) => fields,
+            LogicalType::Bits(b) => {
                 fields.insert(PathName::new_empty(), *b).unwrap();
                 fields
             }
-            LogicalStreamType::Group(Group(inner)) => {
+            LogicalType::Group(Group(inner)) => {
                 inner.iter().for_each(|(name, stream)| {
                     stream.fields().iter().for_each(|(path_name, bit_count)| {
                         fields
@@ -708,7 +705,7 @@ impl LogicalStreamType {
                 });
                 fields
             }
-            LogicalStreamType::Union(Union(inner)) => {
+            LogicalType::Union(Union(inner)) => {
                 if inner.len() > 1 {
                     fields
                         .insert(
@@ -741,15 +738,15 @@ impl LogicalStreamType {
         }
     }
 
-    pub fn synthesize(&self) -> LogicalStream {
-        let split = self.split();
+    pub(crate) fn synthesize(&self) -> LogicalStream {
+        let split = self.split_streams();
         let (signals, rest) = (split.signals.fields(), split.streams);
         LogicalStream {
             signals,
             streams: rest
                 .into_iter()
                 .map(|(path_name, stream)| match stream {
-                    LogicalStreamType::Stream(stream) => (
+                    LogicalType::Stream(stream) => (
                         path_name,
                         PhysicalStream::new(
                             stream.data.fields(),
@@ -768,11 +765,11 @@ impl LogicalStreamType {
         }
     }
 
-    pub fn compatible(&self, other: &LogicalStreamType) -> bool {
+    pub fn compatible(&self, other: &LogicalType) -> bool {
         self == other
             || match other {
-                LogicalStreamType::Stream(other) => match self {
-                    LogicalStreamType::Stream(stream) => {
+                LogicalType::Stream(other) => match self {
+                    LogicalType::Stream(stream) => {
                         stream.data.compatible(&other.data) && stream.complexity < other.complexity
                     }
                     _ => false,
@@ -780,46 +777,231 @@ impl LogicalStreamType {
                 _ => false,
             }
             || match self {
-                LogicalStreamType::Group(Group(source))
-                | LogicalStreamType::Union(Union(source)) => match other {
-                    LogicalStreamType::Group(Group(sink))
-                    | LogicalStreamType::Union(Union(sink)) => {
-                        source.len() == sink.len()
-                            && source.iter().zip(sink.iter()).all(
-                                |((name, stream), (name_, stream_))| {
-                                    name == name_ && stream.compatible(&stream_)
-                                },
-                            )
+                LogicalType::Group(Group(source)) | LogicalType::Union(Union(source)) => {
+                    match other {
+                        LogicalType::Group(Group(sink)) | LogicalType::Union(Union(sink)) => {
+                            source.len() == sink.len()
+                                && source.iter().zip(sink.iter()).all(
+                                    |((name, stream), (name_, stream_))| {
+                                        name == name_ && stream.compatible(&stream_)
+                                    },
+                                )
+                        }
+                        _ => false,
                     }
-                    _ => false,
-                },
+                }
                 _ => false,
             }
+    }
+
+    pub fn split(&self) -> std::vec::IntoIter<LogicalSplitItem> {
+        let split_streams = self.split_streams();
+        let (signals, streams) = (split_streams.signals, split_streams.streams);
+        let mut map = Vec::with_capacity(streams.len() + 1);
+
+        if !signals.is_null() {
+            map.push(LogicalSplitItem::Signals(Signals(signals)));
+        }
+
+        map.extend(streams.into_iter().map(|(path_name, logical_type)| {
+            LogicalSplitItem::Stream(ElementStream {
+                path_name,
+                logical_type,
+            })
+        }));
+        map.into_iter()
+    }
+
+    pub fn physical(&self) -> std::vec::IntoIter<PhysicalSplitItem> {
+        self.split()
+            .map(|item| match item {
+                LogicalSplitItem::Signals(signals) => PhysicalSplitItem::Signals(signals),
+                LogicalSplitItem::Stream(stream) => PhysicalSplitItem::Stream(stream.into()),
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
+/// An element stream with a path name and LogicalType. Contains no nested
+/// streams.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElementStream {
+    path_name: PathName,
+    logical_type: LogicalType,
+}
+
+impl ElementStream {
+    pub fn path_name(&self) -> &[Name] {
+        self.path_name.as_ref()
+    }
+    /// Returns the LogicalType of this element. Contains no nested streams.
+    pub fn logical_type(&self) -> &LogicalType {
+        &self.logical_type
+    }
+    /// Return all fields in this element stream
+    pub fn fields(&self) -> Fields {
+        let mut fields = Fields::new_empty();
+        match &self.logical_type {
+            LogicalType::Stream(stream) => match &*stream.data {
+                LogicalType::Null => fields,
+                LogicalType::Bits(b) => {
+                    fields.insert(self.path_name.clone(), *b).unwrap();
+                    fields
+                }
+                LogicalType::Group(Group(inner)) => {
+                    inner.iter().for_each(|(name, stream)| {
+                        stream.fields().iter().for_each(|(path_name, bit_count)| {
+                            fields
+                                .insert(
+                                    path_name
+                                        .with_parent(name.clone())
+                                        .with_parents(self.path_name.clone()),
+                                    *bit_count,
+                                )
+                                .unwrap();
+                        })
+                    });
+                    fields
+                }
+                LogicalType::Union(Union(inner)) => {
+                    if inner.len() > 1 {
+                        fields
+                            .insert(
+                                PathName::try_new(vec!["tag"])
+                                    .unwrap()
+                                    .with_parents(self.path_name.clone()),
+                                BitCount::new(log2_ceil(
+                                    BitCount::new(inner.len() as NonNegative).unwrap(),
+                                ))
+                                .unwrap(),
+                            )
+                            .unwrap();
+                    }
+                    let b = inner.iter().fold(0, |acc, (_, stream)| {
+                        acc.max(
+                            stream
+                                .fields()
+                                .values()
+                                .fold(0, |acc, count| acc.max(count.get())),
+                        )
+                    });
+                    if b > 0 {
+                        fields
+                            .insert(
+                                PathName::try_new(vec!["union"])
+                                    .unwrap()
+                                    .with_parents(self.path_name.clone()),
+                                BitCount::new(b).unwrap(),
+                            )
+                            .unwrap();
+                    }
+                    fields
+                }
+                LogicalType::Stream(_) => unreachable!(),
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<ElementStream> for PhysicalStream {
+    fn from(element_stream: ElementStream) -> PhysicalStream {
+        match element_stream.logical_type {
+            LogicalType::Stream(stream) => PhysicalStream::new(
+                stream.data.fields(),
+                Positive::new(stream.throughput.get().ceil() as NonNegative).unwrap(),
+                stream.dimensionality,
+                stream.complexity,
+                stream
+                    .user
+                    .map(|stream| stream.fields())
+                    .unwrap_or_else(Fields::new_empty),
+            ),
+            _ => unreachable!(),
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct Signals(LogicalType);
+impl Signals {
+    /// Returns the LogicalType of this element.
+    pub fn logical_type(&self) -> &LogicalType {
+        &self.0
+    }
+    /// Returns all fields in these async signals.
+    pub fn fields(&self) -> Fields {
+        self.0.fields()
+    }
+}
+
+/// A split item is either an async signal (outside streamspace) or an element
+/// stream (no nested streams).
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogicalSplitItem {
+    Signals(Signals),
+    Stream(ElementStream),
+}
+
+impl LogicalSplitItem {
+    pub fn is_stream(&self) -> bool {
+        match self {
+            LogicalSplitItem::Signals(_) => false,
+            LogicalSplitItem::Stream(_) => true,
+        }
+    }
+    pub fn is_signals(&self) -> bool {
+        match self {
+            LogicalSplitItem::Signals(_) => true,
+            LogicalSplitItem::Stream(_) => false,
+        }
+    }
+    pub fn logical_type(&self) -> &LogicalType {
+        match self {
+            LogicalSplitItem::Signals(signals) => signals.logical_type(),
+            LogicalSplitItem::Stream(stream) => stream.logical_type(),
+        }
+    }
+    pub fn fields(&self) -> Fields {
+        match self {
+            LogicalSplitItem::Signals(signals) => signals.fields(),
+            LogicalSplitItem::Stream(stream) => stream.fields(),
+        }
+    }
+}
+
+/// A split item is either an async signal (outside streamspace) or a physical
+/// stream.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PhysicalSplitItem {
+    Signals(Signals),
+    Stream(PhysicalStream),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SplitStreams {
-    signals: LogicalStreamType,
-    streams: IndexMap<PathName, LogicalStreamType>,
+    signals: LogicalType,
+    streams: IndexMap<PathName, LogicalType>,
 }
 
 impl SplitStreams {
-    pub fn streams(&self) -> impl Iterator<Item = (&PathName, &LogicalStreamType)> {
+    pub fn streams(&self) -> impl Iterator<Item = (&PathName, &LogicalType)> {
         self.streams.iter()
     }
-    pub fn signal(&self) -> &LogicalStreamType {
+    pub fn signal(&self) -> &LogicalType {
         &self.signals
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct LogicalStream {
+pub(crate) struct LogicalStream {
     signals: Fields,
     streams: IndexMap<PathName, PhysicalStream>,
 }
 
 impl LogicalStream {
+    #[allow(dead_code)]
     pub fn signals(&self) -> impl Iterator<Item = (&PathName, &BitCount)> {
         self.signals.iter()
     }
@@ -833,21 +1015,21 @@ impl LogicalStream {
 pub(crate) mod tests {
     use super::*;
 
-    /// Module containing functions that return common LogicalStreamTypes that are not streams.
+    /// Module containing functions that return common LogicalTypes that are not streams.
     /// To be used for testing purposes only.
     pub(crate) mod elements {
         use super::*;
 
-        pub(crate) fn prim(bits: u32) -> LogicalStreamType {
-            LogicalStreamType::try_new_bits(bits).unwrap()
+        pub(crate) fn prim(bits: u32) -> LogicalType {
+            LogicalType::try_new_bits(bits).unwrap()
         }
 
         pub(crate) fn group() -> LogicalStreamType {
             LogicalStreamType::try_new_group(vec![("c", prim(42)), ("d", prim(1337))]).unwrap()
         }
 
-        pub(crate) fn group_of_single() -> LogicalStreamType {
-            LogicalStreamType::try_new_group(vec![("a", prim(42))]).unwrap()
+        pub(crate) fn group_of_single() -> LogicalType {
+            LogicalType::try_new_group(vec![("a", prim(42))]).unwrap()
         }
 
         pub(crate) fn group_nested() -> LogicalStreamType {
@@ -855,21 +1037,21 @@ pub(crate) mod tests {
         }
     }
 
-    /// Module containing functions that return common LogicalStreamTypes to be used for testing
+    /// Module containing functions that return common LogicalTypes to be used for testing
     /// purposed only.
     pub(crate) mod streams {
         use super::*;
 
-        pub(crate) fn prim(bits: u32) -> LogicalStreamType {
-            LogicalStreamType::from(Stream::new_basic(elements::prim(bits)))
+        pub(crate) fn prim(bits: u32) -> LogicalType {
+            LogicalType::from(Stream::new_basic(elements::prim(bits)))
         }
 
-        pub(crate) fn group() -> LogicalStreamType {
-            LogicalStreamType::try_new_group(vec![("a", prim(42)), ("b", prim(1337))]).unwrap()
+        pub(crate) fn group() -> LogicalType {
+            LogicalType::try_new_group(vec![("a", prim(42)), ("b", prim(1337))]).unwrap()
         }
 
-        pub(crate) fn nested() -> LogicalStreamType {
-            LogicalStreamType::from(Stream::new_basic(LogicalStreamType::from(Stream {
+        pub(crate) fn nested() -> LogicalType {
+            LogicalType::from(Stream::new_basic(LogicalType::from(Stream {
                 data: Box::new(elements::prim(8)),
                 throughput: PositiveReal::new(1.).unwrap(),
                 dimensionality: 1,
@@ -883,10 +1065,51 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn iterators() -> Result<()> {
+        let group = elements::group();
+        assert_eq!(
+            group.split().collect::<Vec<_>>(),
+            vec![LogicalSplitItem::Signals(Signals(elements::group()))]
+        );
+
+        let stream = LogicalType::from(Stream::new_basic(group.clone()));
+        assert_eq!(
+            stream.split().collect::<Vec<_>>(),
+            vec![LogicalSplitItem::Stream(ElementStream {
+                path_name: PathName::new_empty(),
+                logical_type: stream.clone()
+            })]
+        );
+        assert_eq!(
+            stream.split().map(|i| i.fields()).collect::<Vec<_>>(),
+            vec![group.fields()]
+        );
+
+        let needle: PathName = "a".try_into()?;
+        let nested =
+            LogicalType::try_new_group(vec![("in", stream.clone()), ("out", stream)]).unwrap();
+        assert_eq!(
+            nested
+                .split()
+                .find(|i| {
+                    i.fields().keys().any(|i| {
+                        i.as_ref()
+                            .windows(needle.len())
+                            .any(|name| name == needle.as_ref())
+                    })
+                })
+                .map(|i| i.fields()),
+            nested.split().next().map(|i| i.fields())
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn union() -> Result<()> {
-        let b = LogicalStreamType::try_new_group(vec![("x", 2), ("y", 2)])?;
+        let b = LogicalType::try_new_group(vec![("x", 2), ("y", 2)])?;
         let c = Stream::new(
-            LogicalStreamType::Bits(Positive::new(4).unwrap()),
+            LogicalType::Bits(Positive::new(4).unwrap()),
             PositiveReal::new(1.).unwrap(),
             1,
             Synchronicity::Sync,
@@ -895,12 +1118,12 @@ pub(crate) mod tests {
             None,
             false,
         );
-        let u = LogicalStreamType::try_new_union(vec![
+        let u = LogicalType::try_new_union(vec![
             ("a", 3.try_into()?),
             ("b", b.clone()),
-            ("c", LogicalStreamType::Stream(c)),
+            ("c", LogicalType::Stream(c)),
         ])?;
-        let stream: LogicalStreamType = Stream::new(
+        let stream: LogicalType = Stream::new(
             u,
             PositiveReal::new(1.).unwrap(),
             1,
@@ -944,7 +1167,7 @@ pub(crate) mod tests {
         );
 
         let c = Stream::new(
-            LogicalStreamType::Bits(Positive::new(4).unwrap()),
+            LogicalType::Bits(Positive::new(4).unwrap()),
             PositiveReal::new(1.).unwrap(),
             1,
             Synchronicity::Flatten,
@@ -953,12 +1176,12 @@ pub(crate) mod tests {
             None,
             false,
         );
-        let u = LogicalStreamType::try_new_union(vec![
+        let u = LogicalType::try_new_union(vec![
             ("a", 3.try_into()?),
             ("b", b.clone()),
             ("c", c.into()),
         ])?;
-        let stream: LogicalStreamType = Stream::new(
+        let stream: LogicalType = Stream::new(
             u,
             PositiveReal::new(1.).unwrap(),
             1,
@@ -980,7 +1203,7 @@ pub(crate) mod tests {
         );
 
         let c = Stream::new(
-            LogicalStreamType::Bits(Positive::new(4).unwrap()),
+            LogicalType::Bits(Positive::new(4).unwrap()),
             PositiveReal::new(1.).unwrap(),
             1,
             Synchronicity::Desync,
@@ -989,12 +1212,8 @@ pub(crate) mod tests {
             None,
             false,
         );
-        let u = LogicalStreamType::try_new_union(vec![
-            ("a", 3.try_into()?),
-            ("b", b),
-            ("c", c.into()),
-        ])?;
-        let stream: LogicalStreamType = Stream::new(
+        let u = LogicalType::try_new_union(vec![("a", 3.try_into()?), ("b", b), ("c", c.into())])?;
+        let stream: LogicalType = Stream::new(
             u,
             PositiveReal::new(1.).unwrap(),
             1,

--- a/src/parser/nom.rs
+++ b/src/parser/nom.rs
@@ -1,7 +1,7 @@
 //! Nom-based parsers for Streamlet Definition Files.
 
 use crate::design::{Interface, Mode, Streamlet};
-use crate::logical::{Direction, Group, LogicalStreamType, Stream, Synchronicity, Union};
+use crate::logical::{Direction, Group, LogicalType, Stream, Synchronicity, Union};
 use crate::physical::Complexity;
 use crate::{Name, PositiveReal};
 
@@ -125,43 +125,39 @@ pub fn bool(input: &str) -> Result<&str, bool> {
     })(input)
 }
 
-pub fn null(input: &str) -> Result<&str, LogicalStreamType> {
-    map(tag("Null"), |_| LogicalStreamType::Null)(input)
+pub fn null(input: &str) -> Result<&str, LogicalType> {
+    map(tag("Null"), |_| LogicalType::Null)(input)
 }
 
-pub fn bits(input: &str) -> Result<&str, LogicalStreamType> {
+pub fn bits(input: &str) -> Result<&str, LogicalType> {
     map_res(
         delimited(w(tag("Bits<")), w(digit1), tag(">")),
-        |x: &str| LogicalStreamType::try_new_bits(x.parse().unwrap()).map_err(|_| ()),
+        |x: &str| LogicalType::try_new_bits(x.parse().unwrap()).map_err(|_| ()),
     )(input)
 }
 
-pub fn logical_stream_type(input: &str) -> Result<&str, LogicalStreamType> {
+pub fn logical_stream_type(input: &str) -> Result<&str, LogicalType> {
     alt((null, bits, group, union, stream))(input)
 }
 
-fn fields(input: &str) -> Result<&str, Vec<(Name, LogicalStreamType)>> {
+fn fields(input: &str) -> Result<&str, Vec<(Name, LogicalType)>> {
     separated_list(
         w(tag(",")),
         separated_pair(w(name), w(tag(":")), w(logical_stream_type)),
     )(input)
 }
 
-pub fn group(input: &str) -> Result<&str, LogicalStreamType> {
+pub fn group(input: &str) -> Result<&str, LogicalType> {
     map_res(
         delimited(w(tag("Group<")), w(fields), tag(">")),
-        |fields: Vec<(Name, LogicalStreamType)>| {
-            Group::try_new(fields).map(Into::into).map_err(|_| ())
-        },
+        |fields: Vec<(Name, LogicalType)>| Group::try_new(fields).map(Into::into).map_err(|_| ()),
     )(input)
 }
 
-pub fn union(input: &str) -> Result<&str, LogicalStreamType> {
+pub fn union(input: &str) -> Result<&str, LogicalType> {
     map_res(
         delimited(w(tag("Union<")), w(fields), tag(">")),
-        |fields: Vec<(Name, LogicalStreamType)>| {
-            Union::try_new(fields).map(Into::into).map_err(|_| ())
-        },
+        |fields: Vec<(Name, LogicalType)>| Union::try_new(fields).map(Into::into).map_err(|_| ()),
     )(input)
 }
 
@@ -189,7 +185,7 @@ pub fn direction(input: &str) -> Result<&str, Direction> {
     })(input)
 }
 
-pub fn stream(input: &str) -> Result<&str, LogicalStreamType> {
+pub fn stream(input: &str) -> Result<&str, LogicalType> {
     map_res(
         tuple((
             w(tag("Stream<")),
@@ -218,7 +214,7 @@ pub fn stream(input: &str) -> Result<&str, LogicalStreamType> {
             )),
             tag(">"),
         )),
-        |(_, data, opt, _)| -> std::result::Result<LogicalStreamType, ()> {
+        |(_, data, opt, _)| -> std::result::Result<LogicalType, ()> {
             let throughput = PositiveReal::new(
                 opt.as_ref()
                     .and_then(|opts| opts.get(&'t').map(|x| x.parse().ok()))
@@ -297,7 +293,7 @@ pub fn interface(input: &str) -> Result<&str, Interface> {
             multispace1,
             logical_stream_type,
         )),
-        |(d, n, _, m, _, t): (Option<String>, Name, _, Mode, _, LogicalStreamType)| {
+        |(d, n, _, m, _, t): (Option<String>, Name, _, Mode, _, LogicalType)| {
             Interface::try_new(n, m, t, d).map_err(|_| ())
         },
     )(input)
@@ -372,7 +368,7 @@ mod tests {
 
     #[test]
     fn parse_null() {
-        assert_eq!(null("Null"), Ok(("", LogicalStreamType::Null)));
+        assert_eq!(null("Null"), Ok(("", LogicalType::Null)));
         assert!(null("null").is_err());
     }
 
@@ -380,7 +376,7 @@ mod tests {
     fn parse_bits() {
         assert_eq!(
             bits("Bits<3>"),
-            Ok(("", LogicalStreamType::try_new_bits(3).unwrap()))
+            Ok(("", LogicalType::try_new_bits(3).unwrap()))
         );
     }
 
@@ -391,8 +387,8 @@ mod tests {
             Ok((
                 "",
                 Group::try_new(vec![
-                    ("a", LogicalStreamType::Null),
-                    ("b", LogicalStreamType::try_new_bits(5).unwrap())
+                    ("a", LogicalType::Null),
+                    ("b", LogicalType::try_new_bits(5).unwrap())
                 ])
                 .unwrap()
                 .into()
@@ -407,8 +403,8 @@ mod tests {
             Ok((
                 "",
                 Union::try_new(vec![
-                    ("a", LogicalStreamType::Null),
-                    ("b", LogicalStreamType::try_new_bits(5).unwrap())
+                    ("a", LogicalType::Null),
+                    ("b", LogicalType::try_new_bits(5).unwrap())
                 ])
                 .unwrap()
                 .into()
@@ -453,7 +449,7 @@ mod tests {
             interface("a :  in Null"),
             Ok((
                 "",
-                Interface::try_new("a", Mode::In, LogicalStreamType::Null, None).unwrap()
+                Interface::try_new("a", Mode::In, LogicalType::Null, None).unwrap()
             ))
         );
         assert_eq!(
@@ -466,7 +462,7 @@ mod tests {
                 Interface::try_new(
                     "b",
                     Mode::Out,
-                    LogicalStreamType::try_new_bits(1).unwrap(),
+                    LogicalType::try_new_bits(1).unwrap(),
                     Some(" This is a sweet interface".to_string())
                 )
                 .unwrap()
@@ -481,14 +477,14 @@ mod tests {
             Ok((
                 "",
                 Stream::new(
-                    LogicalStreamType::try_new_union(vec![
-                        ("a", LogicalStreamType::Null),
-                        ("b", LogicalStreamType::try_new_bits(1).unwrap()),
+                    LogicalType::try_new_union(vec![
+                        ("a", LogicalType::Null),
+                        ("b", LogicalType::try_new_bits(1).unwrap()),
                         (
                             "c",
-                            LogicalStreamType::try_new_group(vec![
-                                ("d", LogicalStreamType::Null),
-                                ("e", LogicalStreamType::Null),
+                            LogicalType::try_new_group(vec![
+                                ("d", LogicalType::Null),
+                                ("e", LogicalType::Null),
                             ])
                             .unwrap(),
                         ),
@@ -500,7 +496,7 @@ mod tests {
                     Complexity::new(vec![4, 2]).unwrap(),
                     Direction::Forward,
                     Some(
-                        LogicalStreamType::try_new_group(vec![("u0", 1), ("u1", 2)]).unwrap(),
+                        LogicalType::try_new_group(vec![("u0", 1), ("u1", 2)]).unwrap(),
                     ),
                     false,
                 ).into()
@@ -534,8 +530,7 @@ mod tests {
                             .unwrap()
                         )
                         .with_item(
-                            Interface::try_new("c", Mode::Out, LogicalStreamType::Null, None)
-                                .unwrap()
+                            Interface::try_new("c", Mode::Out, LogicalType::Null, None).unwrap()
                         ),
                     None
                 )
@@ -568,14 +563,14 @@ mod tests {
                         Interface::try_new(
                             "a",
                             Mode::In,
-                            LogicalStreamType::Null,
+                            LogicalType::Null,
                             Some(" Such a weird interface".to_string())
                         )
                         .unwrap(),
                         Interface::try_new(
                             "b",
                             Mode::Out,
-                            LogicalStreamType::Null,
+                            LogicalType::Null,
                             Some(" And another one".to_string())
                         )
                         .unwrap(),


### PR DESCRIPTION
Attempt to close #28. 

- [x] Implementation
- [ ] Documentation
- [ ] Tests
- [ ] Discuss API design

Follow-up PRs can incorporate these interfaces in the `generator` module.