### PR TITLE
Add master branch crate documentation to GitHub pages

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -27,6 +27,24 @@ jobs:
         name: book
         path: book/book
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps --all-features
+    - uses: actions/upload-artifact@v1
+      with:
+        name: docs
+        path: target/doc
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
@@ -36,6 +54,10 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: book
+    - uses: actions/download-artifact@v1
+      with:
+        name: docs
+    - run: mv docs book/
     - uses: alex-page/blazing-fast-gh-pages-deploy@v1.1.0
       with:
         repo-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This puts the crate docs at https://abs-tudelft.github.io/tydi/docs for the `master` branch.